### PR TITLE
Finish init contract testing and tweak some broken stuff

### DIFF
--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -91,7 +91,7 @@ pub fn asset_state<S: Into<String>>(
 }
 
 pub fn asset_state_read<S: Into<String>>(
-    storage: &mut dyn Storage,
+    storage: &dyn Storage,
     asset_type: S,
 ) -> ReadonlySingleton<AssetDefinition> {
     singleton_read(storage, &get_asset_state_key(asset_type))

--- a/src/instantiate/init_contract.rs
+++ b/src/instantiate/init_contract.rs
@@ -42,3 +42,219 @@ pub fn init_contract(
         //.add_message(bind_name_msg)
         .add_attribute("action", "init"))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::contract::instantiate;
+    use crate::core::error::ContractError;
+    use crate::core::msg::InitMsg;
+    use crate::core::state::{asset_state_read, AssetDefinition, FeeDestination, ValidatorDetail};
+    use crate::testutil::test_utilities::{
+        get_default_asset_definitions, test_instantiate, InstArgs, DEFAULT_ASSET_TYPE,
+        DEFAULT_CONTRACT_BASE_NAME, DEFAULT_INFO_NAME, DEFAULT_ONBOARDING_COST,
+        DEFAULT_VALIDATOR_ADDRESS,
+    };
+    use crate::util::functions::generate_asset_attribute_name;
+    use cosmwasm_std::testing::{mock_info, MOCK_CONTRACT_ADDR};
+    use cosmwasm_std::{coin, CosmosMsg, Decimal, SubMsg, Uint128};
+    use provwasm_mocks::mock_dependencies;
+    use provwasm_std::{NameMsgParams, ProvenanceMsg, ProvenanceMsgParams};
+
+    #[test]
+    fn test_valid_default_init() {
+        let mut deps = mock_dependencies(&[]);
+        let response = test_instantiate(deps.as_mut(), InstArgs::default())
+            .expect("the default instantiate should produce a response without error");
+        assert_eq!(
+            1,
+            response.attributes.len(),
+            "a single attribute should be emitted"
+        );
+        let attribute = response.attributes.first().unwrap();
+        assert_eq!(
+            "action",
+            attribute.key.as_str(),
+            "the attribute key should be `action`"
+        );
+        assert_eq!(
+            "init",
+            attribute.value.as_str(),
+            "the attribute value should be `init`"
+        );
+        assert_eq!(
+            1,
+            response.messages.len(),
+            "a single message should be emitted"
+        );
+        test_message_is_name_bind(&response.messages, DEFAULT_ASSET_TYPE);
+        let asset_state = asset_state_read(deps.as_ref().storage, DEFAULT_ASSET_TYPE)
+            .load()
+            .expect("expected the asset state data should be added to storage");
+        assert_eq!(
+            DEFAULT_ASSET_TYPE, asset_state.asset_type,
+            "the asset type should be stored correctly",
+        );
+        assert_eq!(
+            1,
+            asset_state.validators.len(),
+            "one validator should be properly stored",
+        );
+        assert_eq!(
+            asset_state,
+            get_default_asset_definitions().first().unwrap().to_owned(),
+            "the returned value should directly match the default asset definition"
+        );
+    }
+
+    #[test]
+    fn test_valid_init_with_multiple_asset_definitions() {
+        let mut deps = mock_dependencies(&[]);
+        let first_asset_def = AssetDefinition::new(
+            "heloc".to_string(),
+            vec![ValidatorDetail::new(
+                DEFAULT_VALIDATOR_ADDRESS.into(),
+                DEFAULT_ONBOARDING_COST.into(),
+                Decimal::percent(50),
+                vec![FeeDestination::new(
+                    "first".to_string(),
+                    Decimal::percent(100),
+                )],
+            )],
+        );
+        let second_asset_def = AssetDefinition::new(
+            "mortgage".to_string(),
+            vec![ValidatorDetail::new(
+                "other-address".to_string(),
+                Uint128::new(150),
+                Decimal::percent(100),
+                vec![
+                    FeeDestination::new("first".to_string(), Decimal::percent(50)),
+                    FeeDestination::new("second".to_string(), Decimal::percent(50)),
+                ],
+            )],
+        );
+        let response = test_instantiate(
+            deps.as_mut(),
+            InstArgs {
+                asset_definitions: vec![first_asset_def.clone(), second_asset_def.clone()],
+                ..Default::default()
+            },
+        )
+        .expect("instantiation should succeed with multiple asset definitions");
+        assert_eq!(
+            1,
+            response.attributes.len(),
+            "only one attribute should be emitted"
+        );
+        assert_eq!(
+            2,
+            response.messages.len(),
+            "two messages should be emitted. one per asset type"
+        );
+        test_message_is_name_bind(&response.messages, "heloc");
+        test_message_is_name_bind(&response.messages, "mortgage");
+        let heloc_asset_state = asset_state_read(deps.as_ref().storage, "heloc")
+            .load()
+            .expect("the heloc asset definition should be added to the state");
+        assert_eq!(
+            first_asset_def, heloc_asset_state,
+            "the heloc asset state should equate to the heloc input"
+        );
+        let mortgage_asset_state = asset_state_read(deps.as_ref().storage, "mortgage")
+            .load()
+            .expect("the mortgage asset definition should be added to the state");
+        assert_eq!(
+            second_asset_def, mortgage_asset_state,
+            "the mortgage asset state should equate to the mortgage input"
+        );
+    }
+
+    #[test]
+    fn test_invalid_init_contract_including_funds() {
+        let mut deps = mock_dependencies(&[]);
+        let error = test_instantiate(
+            deps.as_mut(),
+            InstArgs {
+                info: mock_info(DEFAULT_INFO_NAME, &[coin(100, "nhash")]),
+                ..Default::default()
+            },
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, ContractError::InvalidFunds(_)),
+            "the responding error should indicate invalid funds",
+        );
+    }
+
+    #[test]
+    fn test_invalid_init_fails_for_invalid_init_msg() {
+        let args = InstArgs {
+            asset_definitions: vec![AssetDefinition::new(String::new(), vec![])],
+            ..Default::default()
+        };
+        let error = instantiate(
+            mock_dependencies(&[]).as_mut(),
+            args.env,
+            args.info,
+            InitMsg {
+                base_contract_name: DEFAULT_CONTRACT_BASE_NAME.to_string(),
+                asset_definitions: args.asset_definitions,
+            },
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, ContractError::InvalidMessageFields { .. }),
+            "the responding error should indicate that the InitMsg was badly formatted",
+        );
+    }
+
+    // Ensures that the slice of SubMsg contains the correct name binding by iterating over all
+    // contained values and extracting the values within
+    fn test_message_is_name_bind(messages: &[SubMsg<ProvenanceMsg>], expected_asset_type: &str) {
+        for message in messages {
+            match &message.msg {
+                CosmosMsg::Custom(msg) => match &msg.params {
+                    ProvenanceMsgParams::Name(param) => match param {
+                        NameMsgParams::BindName {
+                            name,
+                            address,
+                            restrict,
+                        } => {
+                            // Wrong name? Go to the next iteration
+                            if !name.contains(expected_asset_type) {
+                                continue;
+                            }
+                            assert_eq!(
+                                &generate_asset_attribute_name(
+                                    expected_asset_type,
+                                    DEFAULT_CONTRACT_BASE_NAME
+                                ),
+                                name,
+                                "the default values should be used to derive the attribute name",
+                            );
+                            assert_eq!(
+                                MOCK_CONTRACT_ADDR,
+                                address.as_str(),
+                                "the default contract address should be bound to",
+                            );
+                            assert!(
+                                restrict,
+                                "the restrict value should be set to true for all bound attributes"
+                            );
+                            // Exit early after finding the appropriate value to ensure the trailing
+                            // panic doesn't fire
+                            return;
+                        }
+                        _ => panic!("unexpected name module message type was emitted"),
+                    },
+                    _ => panic!("unexpected provenance message type was emitted"),
+                },
+                _ => panic!("unexpected message type was emitted"),
+            }
+        }
+        panic!(
+            "failed to find message for expected asset type `{}`",
+            expected_asset_type
+        );
+    }
+}

--- a/src/validation/validate_init_msg.rs
+++ b/src/validation/validate_init_msg.rs
@@ -111,6 +111,11 @@ fn validate_validator(validator: &ValidatorDetail, deps: &DepsC) -> Vec<String> 
             )
         }
     }
+    if distinct_count_by_property(&validator.fee_destinations, |dest| &dest.address)
+        != validator.fee_destinations.len()
+    {
+        invalid_fields.push("validator:fee_destinations: all fee destinations within a validator must have unique addresses".to_string());
+    }
     let mut fee_destination_messages = validator
         .fee_destinations
         .iter()
@@ -517,6 +522,22 @@ pub mod tests {
                 ],
             ),
             "validator:fee_destinations: fee destinations' fee percents must cleanly sum to the fee_total. Fee total: 20nhash, Destination sum: 19nhash",
+        );
+    }
+
+    #[test]
+    fn test_invalid_validator_destinations_contains_duplicate_address() {
+        test_invalid_validator(
+            &ValidatorDetail::new(
+                "address".to_string(),
+                Uint128::new(100),
+                Decimal::percent(50),
+                vec![
+                    FeeDestination::new("fee-guy".to_string(), Decimal::percent(50)),
+                    FeeDestination::new("fee-guy".to_string(), Decimal::percent(50)),
+                ]
+            ),
+            "validator:fee_destinations: all fee destinations within a validator must have unique addresses",
         );
     }
 


### PR DESCRIPTION
- `asset_state_read` was taking a mutable storage object.  This is fine, but inherently incorrect because the readonly version does not mutate the values.
- `validate_init_msg` function was not checking if the provided `FeeDestination` structs had duplicate addresses in them. That would just be weird.
- Adds tests for happy / sad path for the `init_contract` function, closing the loop on this functionality.  Now we only need to mod this stuff when/if we add to it, and it should work just fine from here forward.