### PR TITLE
ToggleAssetState: Prevent duplicate calls from producing unexpected results

### DIFF
--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -111,11 +111,15 @@
         "toggle_asset_definition": {
           "type": "object",
           "required": [
-            "asset_type"
+            "asset_type",
+            "expected_result"
           ],
           "properties": {
             "asset_type": {
               "type": "string"
+            },
+            "expected_result": {
+              "type": "boolean"
             }
           }
         }

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -21,6 +21,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "query_state"
+      ],
+      "properties": {
+        "query_state": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -83,6 +83,9 @@ pub enum ContractError {
     #[error("Unauthorized: {explanation}")]
     Unauthorized { explanation: String },
 
+    #[error("Unexpected state: {explanation}")]
+    UnexpectedState { explanation: String },
+
     #[error("Requested functionality is not yet implemented")]
     Unimplemented,
 

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -56,6 +56,7 @@ pub enum ExecuteMsg {
     },
     ToggleAssetDefinition {
         asset_type: String,
+        expected_result: bool,
     },
     AddAssetValidator {
         asset_type: String,

--- a/src/execute/onboard_asset.rs
+++ b/src/execute/onboard_asset.rs
@@ -230,7 +230,7 @@ mod tests {
         toggle_asset_definition(
             deps.as_mut(),
             empty_mock_info(),
-            ToggleAssetDefinitionV1::new(DEFAULT_ASSET_TYPE),
+            ToggleAssetDefinitionV1::new(DEFAULT_ASSET_TYPE, false),
         )
         .expect("toggling the asset definition to be disabled should succeed");
         let err = onboard_asset(

--- a/src/validation/validate_execute_msg.rs
+++ b/src/validation/validate_execute_msg.rs
@@ -22,7 +22,7 @@ pub fn validate_execute_msg(msg: &ExecuteMsg, deps: &DepsC) -> Result<(), Contra
         ExecuteMsg::UpdateAssetDefinition { asset_definition } => {
             validate_asset_definition(&asset_definition.into(), deps)
         }
-        ExecuteMsg::ToggleAssetDefinition { asset_type } => {
+        ExecuteMsg::ToggleAssetDefinition { asset_type, .. } => {
             validate_toggle_asset_definition(asset_type)
         }
         ExecuteMsg::AddAssetValidator {


### PR DESCRIPTION
Prevent duplicate (assumedly accidental) calls to `ToggleAssetState` from running unless each call explicitly states the value it wants to achieve.  This keeps the route as a toggle route, but the caller needs to provide up-front via a new `expected_result` field whether or not they intend to toggle on or off.