### PR TITLE
Serde input improvements / fixes

### DIFF
--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -226,42 +226,38 @@
         {
           "type": "object",
           "required": [
-            "asset_uuid"
+            "type",
+            "value"
           ],
           "properties": {
-            "asset_uuid": {
-              "type": "object",
-              "required": [
+            "type": {
+              "type": "string",
+              "enum": [
                 "asset_uuid"
-              ],
-              "properties": {
-                "asset_uuid": {
-                  "type": "string"
-                }
-              }
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "type": "object",
           "required": [
-            "scope_address"
+            "type",
+            "value"
           ],
           "properties": {
-            "scope_address": {
-              "type": "object",
-              "required": [
+            "type": {
+              "type": "string",
+              "enum": [
                 "scope_address"
-              ],
-              "properties": {
-                "scope_address": {
-                  "type": "string"
-                }
-              }
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         }
       ]
     },
@@ -289,42 +285,38 @@
         {
           "type": "object",
           "required": [
-            "scope_spec_uuid"
+            "type",
+            "value"
           ],
           "properties": {
-            "scope_spec_uuid": {
-              "type": "object",
-              "required": [
-                "scope_spec_uuid"
-              ],
-              "properties": {
-                "scope_spec_uuid": {
-                  "type": "string"
-                }
-              }
+            "type": {
+              "type": "string",
+              "enum": [
+                "uuid"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "type": "object",
           "required": [
-            "scope_spec_address"
+            "type",
+            "value"
           ],
           "properties": {
-            "scope_spec_address": {
-              "type": "object",
-              "required": [
-                "scope_spec_address"
-              ],
-              "properties": {
-                "scope_spec_address": {
-                  "type": "string"
-                }
-              }
+            "type": {
+              "type": "string",
+              "enum": [
+                "address"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         }
       ]
     },

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -71,42 +71,38 @@
         {
           "type": "object",
           "required": [
-            "scope_spec_uuid"
+            "type",
+            "value"
           ],
           "properties": {
-            "scope_spec_uuid": {
-              "type": "object",
-              "required": [
-                "scope_spec_uuid"
-              ],
-              "properties": {
-                "scope_spec_uuid": {
-                  "type": "string"
-                }
-              }
+            "type": {
+              "type": "string",
+              "enum": [
+                "uuid"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "type": "object",
           "required": [
-            "scope_spec_address"
+            "type",
+            "value"
           ],
           "properties": {
-            "scope_spec_address": {
-              "type": "object",
-              "required": [
-                "scope_spec_address"
-              ],
-              "properties": {
-                "scope_spec_address": {
-                  "type": "string"
-                }
-              }
+            "type": {
+              "type": "string",
+              "enum": [
+                "address"
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         }
       ]
     },

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -61,42 +61,38 @@
         {
           "type": "object",
           "required": [
-            "asset_uuid"
+            "type",
+            "value"
           ],
           "properties": {
-            "asset_uuid": {
-              "type": "object",
-              "required": [
+            "type": {
+              "type": "string",
+              "enum": [
                 "asset_uuid"
-              ],
-              "properties": {
-                "asset_uuid": {
-                  "type": "string"
-                }
-              }
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "type": "object",
           "required": [
-            "scope_address"
+            "type",
+            "value"
           ],
           "properties": {
-            "scope_address": {
-              "type": "object",
-              "required": [
+            "type": {
+              "type": "string",
+              "enum": [
                 "scope_address"
-              ],
-              "properties": {
-                "scope_address": {
-                  "type": "string"
-                }
-              }
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         }
       ]
     },
@@ -105,42 +101,38 @@
         {
           "type": "object",
           "required": [
-            "asset_type"
+            "type",
+            "value"
           ],
           "properties": {
-            "asset_type": {
-              "type": "object",
-              "required": [
+            "type": {
+              "type": "string",
+              "enum": [
                 "asset_type"
-              ],
-              "properties": {
-                "asset_type": {
-                  "type": "string"
-                }
-              }
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         },
         {
           "type": "object",
           "required": [
-            "scope_spec_address"
+            "type",
+            "value"
           ],
           "properties": {
-            "scope_spec_address": {
-              "type": "object",
-              "required": [
+            "type": {
+              "type": "string",
+              "enum": [
                 "scope_spec_address"
-              ],
-              "properties": {
-                "scope_spec_address": {
-                  "type": "string"
-                }
-              }
+              ]
+            },
+            "value": {
+              "type": "string"
             }
-          },
-          "additionalProperties": false
+          }
         }
       ]
     }

--- a/src/core/asset.rs
+++ b/src/core/asset.rs
@@ -53,6 +53,7 @@ impl AssetDefinition {
 /// Allows the user to optionally specify the enabled flag on an asset definition, versus forcing
 /// it to be added manually on every request, when it will likely always be specified as `true`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub struct AssetDefinitionInput {
     pub asset_type: String,
     pub scope_spec_identifier: ScopeSpecIdentifier,
@@ -238,35 +239,31 @@ impl AssetScopeAttribute {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum AssetIdentifier {
-    AssetUuid { asset_uuid: String },
-    ScopeAddress { scope_address: String },
+    AssetUuid(String),
+    ScopeAddress(String),
 }
 impl AssetIdentifier {
     pub fn asset_uuid<S: Into<String>>(asset_uuid: S) -> Self {
-        Self::AssetUuid {
-            asset_uuid: asset_uuid.into(),
-        }
+        Self::AssetUuid(asset_uuid.into())
     }
 
     pub fn scope_address<S: Into<String>>(scope_address: S) -> Self {
-        Self::ScopeAddress {
-            scope_address: scope_address.into(),
-        }
+        Self::ScopeAddress(scope_address.into())
     }
 
     pub fn get_asset_uuid(&self) -> ContractResult<String> {
         match self {
-            Self::AssetUuid { asset_uuid } => (*asset_uuid).clone().to_ok(),
-            Self::ScopeAddress { scope_address } => scope_address_to_asset_uuid(scope_address),
+            Self::AssetUuid(asset_uuid) => (*asset_uuid).clone().to_ok(),
+            Self::ScopeAddress(scope_address) => scope_address_to_asset_uuid(scope_address),
         }
     }
 
     pub fn get_scope_address(&self) -> ContractResult<String> {
         match self {
-            Self::AssetUuid { asset_uuid } => asset_uuid_to_scope_address(asset_uuid),
-            Self::ScopeAddress { scope_address } => (*scope_address).clone().to_ok(),
+            Self::AssetUuid(asset_uuid) => asset_uuid_to_scope_address(asset_uuid),
+            Self::ScopeAddress(scope_address) => (*scope_address).clone().to_ok(),
         }
     }
 
@@ -292,48 +289,40 @@ impl AssetIdentifiers {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum AssetQualifier {
-    AssetType { asset_type: String },
-    ScopeSpecAddress { scope_spec_address: String },
+    AssetType(String),
+    ScopeSpecAddress(String),
 }
 impl AssetQualifier {
     pub fn asset_type<S: Into<String>>(asset_type: S) -> Self {
-        Self::AssetType {
-            asset_type: asset_type.into(),
-        }
+        Self::AssetType(asset_type.into())
     }
 
     pub fn scope_spec_address<S: Into<String>>(scope_spec_address: S) -> Self {
-        Self::ScopeSpecAddress {
-            scope_spec_address: scope_spec_address.into(),
-        }
+        Self::ScopeSpecAddress(scope_spec_address.into())
     }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "type", content = "value")]
 pub enum ScopeSpecIdentifier {
-    ScopeSpecUuid { scope_spec_uuid: String },
-    ScopeSpecAddress { scope_spec_address: String },
+    Uuid(String),
+    Address(String),
 }
 impl ScopeSpecIdentifier {
     pub fn uuid<S: Into<String>>(scope_spec_uuid: S) -> Self {
-        Self::ScopeSpecUuid {
-            scope_spec_uuid: scope_spec_uuid.into(),
-        }
+        Self::Uuid(scope_spec_uuid.into())
     }
 
     pub fn address<S: Into<String>>(scope_spec_address: S) -> Self {
-        Self::ScopeSpecAddress {
-            scope_spec_address: scope_spec_address.into(),
-        }
+        Self::Address(scope_spec_address.into())
     }
 
     pub fn get_scope_spec_uuid(&self) -> ContractResult<String> {
         match self {
-            Self::ScopeSpecUuid { scope_spec_uuid } => (*scope_spec_uuid).clone().to_ok(),
-            Self::ScopeSpecAddress { scope_spec_address } => {
+            Self::Uuid(scope_spec_uuid) => (*scope_spec_uuid).clone().to_ok(),
+            Self::Address(scope_spec_address) => {
                 scope_spec_address_to_scope_spec_uuid(scope_spec_address)
             }
         }
@@ -341,10 +330,8 @@ impl ScopeSpecIdentifier {
 
     pub fn get_scope_spec_address(&self) -> ContractResult<String> {
         match self {
-            Self::ScopeSpecUuid { scope_spec_uuid } => {
-                scope_spec_uuid_to_scope_spec_address(scope_spec_uuid)
-            }
-            Self::ScopeSpecAddress { scope_spec_address } => (*scope_spec_address).clone().to_ok(),
+            Self::Uuid(scope_spec_uuid) => scope_spec_uuid_to_scope_spec_address(scope_spec_uuid),
+            Self::Address(scope_spec_address) => (*scope_spec_address).clone().to_ok(),
         }
     }
 

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 use super::asset::{AssetDefinitionInput, AssetIdentifier, AssetQualifier};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
 pub struct InitMsg {
     pub base_contract_name: String,
     pub asset_definitions: Vec<AssetDefinitionInput>,

--- a/src/query/query_asset_definition.rs
+++ b/src/query/query_asset_definition.rs
@@ -6,10 +6,10 @@ use cosmwasm_std::{to_binary, Binary};
 
 pub fn query_asset_definition(deps: &DepsC, qualifier: AssetQualifier) -> ContractResult<Binary> {
     let asset_definition = match qualifier {
-        AssetQualifier::AssetType { asset_type } => {
+        AssetQualifier::AssetType(asset_type) => {
             load_asset_definition_by_type(deps.storage, asset_type)
         }
-        AssetQualifier::ScopeSpecAddress { scope_spec_address } => {
+        AssetQualifier::ScopeSpecAddress(scope_spec_address) => {
             load_asset_definition_by_scope_spec(deps.storage, scope_spec_address)
         }
     }?;

--- a/src/query/query_asset_scope_attribute.rs
+++ b/src/query/query_asset_scope_attribute.rs
@@ -20,10 +20,10 @@ pub fn query_asset_scope_attribute(
     identifier: AssetIdentifier,
 ) -> ContractResult<Binary> {
     let scope_attribute = match identifier {
-        AssetIdentifier::AssetUuid { asset_uuid } => {
+        AssetIdentifier::AssetUuid(asset_uuid) => {
             query_scope_attribute_by_asset_uuid(deps, asset_uuid)
         }
-        AssetIdentifier::ScopeAddress { scope_address } => {
+        AssetIdentifier::ScopeAddress(scope_address) => {
             query_scope_attribute_by_scope_address(deps, scope_address)
         }
     }?;

--- a/src/validation/validate_execute_msg.rs
+++ b/src/validation/validate_execute_msg.rs
@@ -43,12 +43,12 @@ fn validate_onboard_asset(
 ) -> ContractResult<()> {
     let mut invalid_fields: Vec<String> = vec![];
     match identifier {
-        AssetIdentifier::AssetUuid { asset_uuid } => {
+        AssetIdentifier::AssetUuid(asset_uuid) => {
             if asset_uuid.is_empty() {
                 invalid_fields.push("identifier:asset_uuid: must not be blank".to_string());
             }
         }
-        AssetIdentifier::ScopeAddress { scope_address } => {
+        AssetIdentifier::ScopeAddress(scope_address) => {
             if scope_address.is_empty() {
                 invalid_fields.push("identifier:scope_address: must not be blank".to_string());
             }
@@ -74,12 +74,12 @@ fn validate_onboard_asset(
 fn validate_validate_asset(identifier: &AssetIdentifier) -> ContractResult<()> {
     let mut invalid_fields: Vec<String> = vec![];
     match identifier {
-        AssetIdentifier::AssetUuid { asset_uuid } => {
+        AssetIdentifier::AssetUuid(asset_uuid) => {
             if asset_uuid.is_empty() {
                 invalid_fields.push("identifier:asset_uuid: must not be blank".to_string());
             }
         }
-        AssetIdentifier::ScopeAddress { scope_address } => {
+        AssetIdentifier::ScopeAddress(scope_address) => {
             if scope_address.is_empty() {
                 invalid_fields.push("identifier:scope_address: must not be blank".to_string());
             }


### PR DESCRIPTION
The current way of using the asset qualifiers is to provide them in a very clear and unnecessarily verbose way:
```json
"scope_spec_identifier": {
  "scope_spec_uuid": {
    "scope_spec_uuid": "ce2aa0ae-a484-11ec-8ac1-cbf7daea950f"
  }
}
```

This alters the input to be simpler:
```json
"scope_spec_identifier": {
  "type": "uuid",
  "value": "ce2aa0ae-a484-11ec-8ac1-cbf7daea950f"
}
```