### PR TITLE
v2.0.1: Verifier Self-Updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "2.0.0"
+version = "2.0.1"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ parameter, or the request will be rejected.
 ```
 
 #### [Update Asset Verifier](src/execute/update_asset_verifier.rs)
-__This route is only accessible to the contract's admin address.__ This route updates an existing [VerifierDetailV2](src/core/types/verifier_detail.rs)
+__This route is only accessible to the contract's admin address or the address of the verifier being updated.__ This route updates an existing [VerifierDetailV2](src/core/types/verifier_detail.rs)
 in an existing [AssetDefinitionV2](src/core/types/asset_definition.rs).  This route is intended to be used when the values
 of a single verifier detail need to change, but not the entire asset definition.  The request will be rejected if the
 referenced asset definition is not present within the contract, or if a verifier does not exist within the asset

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -177,7 +177,7 @@
       "additionalProperties": false
     },
     {
-      "description": "__This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).  This route is intended to register new verifiers without the bulky requirements of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) execution route.  This route will reject verifiers added with addresses that match any other verifiers on the target asset definition.",
+      "description": "__This route is only accessible to the contract's admin address or the address of the verifier being updated.__ This route adds a new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).  This route is intended to register new verifiers without the bulky requirements of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) execution route.  This route will reject verifiers added with addresses that match any other verifiers on the target asset definition.",
       "type": "object",
       "required": [
         "add_asset_verifier"

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use super::types::access_route::AccessRoute;
 
 /// The struct used to instantiate the contract.  Utilized in the core [contract file](crate::contract::instantiate).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct InitMsg {
     /// The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitionV2s](super::types::asset_definition::AssetDefinitionV2)
@@ -31,7 +31,7 @@ pub struct InitMsg {
 
 /// Defines all routes in which the contract can be queried.  These are all handled directly in
 /// the [contract file](crate::contract::query).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
     /// This route can be used to retrieve a specific [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) from the contract's
@@ -78,7 +78,7 @@ pub enum QueryMsg {
 
 /// Defines all routes in which the contract can be executed.  These are all handled directly in
 /// the [contract file](crate::contract::execute).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
     /// This route is the primary interaction point for most consumers.  It consumes an asset uuid or scope address, the type of
@@ -178,7 +178,7 @@ pub enum ExecuteMsg {
         /// the asset definition is in the intended state during the execution of the route.
         expected_result: bool,
     },
-    /// __This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2)
+    /// __This route is only accessible to the contract's admin address or the address of the verifier being updated.__ This route adds a new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2)
     /// to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).  This route is intended to register new verifiers
     /// without the bulky requirements of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) execution route.  This route will reject verifiers added
     /// with addresses that match any other verifiers on the target asset definition.
@@ -242,7 +242,7 @@ pub enum ExecuteMsg {
 
 /// The struct used to migrate the contract from one code instance to another.  Utilized in the core
 /// [contract file](crate::contract::migrate).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MigrateMsg {
     /// Performs a standard migration using the underlying [migrate_contract](crate::migrate::migrate_contract::migrate_contract)
@@ -255,7 +255,7 @@ pub enum MigrateMsg {
 }
 
 /// Sub-level struct that defines optional changes that can occur during the migration process.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrationOptions {
     /// Sets the contract admin to a new address when populated.  Must be a valid Provenance

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -22,7 +22,7 @@ const FEE_PAYMENT_DETAIL_NAMESPACE: &str = "fee_payment_detail";
 const FEE_PAYMENT_DETAILS: Map<String, FeePaymentDetail> = Map::new(FEE_PAYMENT_DETAIL_NAMESPACE);
 
 /// Stores the main configurations for the contract internally.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct StateV2 {
     /// The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitions](super::types::access_definition::AccessDefinition)
     /// will use this value as their parent name.

--- a/src/core/types/access_definition.rs
+++ b/src/core/types/access_definition.rs
@@ -8,7 +8,7 @@ use crate::util::{
 use super::access_route::AccessRoute;
 
 /// Allows access definitions to be differentiated based on their overarching type, versus having to differentiate them based on known addresses.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AccessDefinitionType {
     /// Indicates that the access definition was created by the requestor that onboarded the scope.
@@ -18,7 +18,7 @@ pub enum AccessDefinitionType {
 }
 
 /// Defines a collection of [AccessRoute](super::access_route::AccessRoute) for a specific address.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AccessDefinition {
     /// The bech32 address of the account that created the underlying [AccessRoutes](super::access_route::AccessRoute).

--- a/src/core/types/asset_definition.rs
+++ b/src/core/types/asset_definition.rs
@@ -15,7 +15,7 @@ use crate::{
 
 /// Defines a specific asset type associated with the contract.  Allows its specified type to be
 /// onboarded and verified.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AssetDefinitionV2 {
     /// The unique name of the asset associated with the definition.
@@ -95,7 +95,7 @@ impl AssetDefinitionV2 {
 
 /// Allows the user to optionally specify the enabled flag on an asset definition, versus forcing
 /// it to be added manually on every request, when it will likely always be specified as `true`.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AssetDefinitionInputV2 {
     /// The name of the asset associated with the definition.  This value must be unique across all

--- a/src/core/types/asset_identifier.rs
+++ b/src/core/types/asset_identifier.rs
@@ -13,7 +13,7 @@ const ASSET_UUID_NAME: &str = "asset_uuid";
 const SCOPE_ADDRESS_NAME: &str = "scope_address";
 
 /// An enum containing interchangeable values that can be used to define an asset (uuid or address).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AssetIdentifier {
     /// A uuid v4 represented by a string.

--- a/src/core/types/asset_onboarding_status.rs
+++ b/src/core/types/asset_onboarding_status.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// An enum that denotes the various states that an [AssetScopeAttribute](super::asset_scope_attribute::AssetScopeAttribute) can have.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AssetOnboardingStatus {
     /// Indicates that the asset has been onboarded but has yet to be verified.

--- a/src/core/types/asset_qualifier.rs
+++ b/src/core/types/asset_qualifier.rs
@@ -9,7 +9,7 @@ const ASSET_TYPE_NAME: &str = "asset_type";
 const SCOPE_SPEC_ADDRESS_NAME: &str = "scope_spec_address";
 
 /// An enum containing different identifiers that can be used to fetch an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AssetQualifier {
     /// The unique name for an asset type.  Ex: heloc, payable, etc.

--- a/src/core/types/asset_scope_attribute.rs
+++ b/src/core/types/asset_scope_attribute.rs
@@ -18,7 +18,7 @@ use super::{
 
 /// An asset scope attribute contains all relevant information for asset classification, and is serialized directly
 /// as json into a Provenance Blockchain Attribute Module attribute on a Provenance Blockchain Metadata Scope.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AssetScopeAttribute {
     /// A unique uuid v4 value that defines the asset contained within the scope.

--- a/src/core/types/asset_verification_result.rs
+++ b/src/core/types/asset_verification_result.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// A simple wrapper for the result of a verification for a scope.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AssetVerificationResult {
     /// A free-form message describing the result of the verification process.

--- a/src/core/types/entity_detail.rs
+++ b/src/core/types/entity_detail.rs
@@ -2,7 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Various fields describing an entity, which could be an organization, account, etc.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct EntityDetail {
     /// A short name describing the entity.

--- a/src/core/types/fee_destination.rs
+++ b/src/core/types/fee_destination.rs
@@ -5,7 +5,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Defines an external account designated as a recipient of funds during the verification process.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct FeeDestinationV2 {
     /// The Provenance Blockchain bech32 address belonging to the account.

--- a/src/core/types/scope_spec_identifier.rs
+++ b/src/core/types/scope_spec_identifier.rs
@@ -15,7 +15,7 @@ const UUID_NAME: &str = "uuid";
 const ADDRESS_NAME: &str = "address";
 
 /// An enum containing interchangeable values that can be used to define a Provenance Blockchain Metadata Scope Specification.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ScopeSpecIdentifier {
     /// A uuid v4 represented by a string.

--- a/src/core/types/serialized_enum.rs
+++ b/src/core/types/serialized_enum.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 /// It's also worth noting that this solution can only create enum switches that have Strings as
 /// their values.  Anything different will not work for this solution and will require further
 /// adaptation and hackery.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct SerializedEnum {
     /// Specifies the type of enum to deserialize into. Maps into one of the values specified in

--- a/src/core/types/verifier_detail.rs
+++ b/src/core/types/verifier_detail.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::entity_detail::EntityDetail;
 
 /// Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct VerifierDetailV2 {
     /// The Provenance Blockchain bech32 address of the verifier account.

--- a/src/execute/add_asset_definition.rs
+++ b/src/execute/add_asset_definition.rs
@@ -20,7 +20,7 @@ use provwasm_std::{bind_name, NameBinding};
 /// * `bind_name` An optional parameter.  If omitted or provided as `true`, the contract will attempt
 /// to bind a name branched off of its [base_contract_name](crate::core::state::StateV2::base_contract_name)
 /// with the provided definition's [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type).
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct AddAssetDefinitionV1 {
     pub asset_definition: AssetDefinitionV2,
     pub bind_name: Option<bool>,

--- a/src/execute/add_asset_verifier.rs
+++ b/src/execute/add_asset_verifier.rs
@@ -18,7 +18,7 @@ use cosmwasm_std::{MessageInfo, Response};
 /// in contract storage.
 /// * `verifier` The verifier detail to use in the [add_asset_verifier](self::add_asset_verifier)
 /// request.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct AddAssetVerifierV1 {
     pub asset_type: String,
     pub verifier: VerifierDetailV2,

--- a/src/execute/onboard_asset.rs
+++ b/src/execute/onboard_asset.rs
@@ -35,7 +35,7 @@ use provwasm_std::ProvenanceQuerier;
 /// * `access_routes` A vector of access routes to be added to the generated [AssetScopeAttribute's](crate::core::types::asset_scope_attribute::AssetScopeAttribute)
 /// [AccessDefinition](crate::core::types::access_definition::AccessDefinition) for the [Requestor](crate::core::types::access_definition::AccessDefinitionType::Requestor)
 /// entry.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OnboardAssetV1 {
     pub identifier: AssetIdentifier,
     pub asset_type: String,

--- a/src/execute/toggle_asset_definition.rs
+++ b/src/execute/toggle_asset_definition.rs
@@ -23,7 +23,7 @@ use crate::{
 /// after the toggle takes place.  This value is required to ensure that multiple toggles executed
 /// in succession (either by accident or by various unrelated callers) will only be honored if
 /// the asset definition is in the intended state during the execution of the route.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ToggleAssetDefinitionV1 {
     pub asset_type: String,
     pub expected_result: bool,

--- a/src/execute/update_access_routes.rs
+++ b/src/execute/update_access_routes.rs
@@ -29,7 +29,7 @@ use cosmwasm_std::{MessageInfo, Response};
 /// instead of the existing routes.  If other existing routes need to be maintained and the updated
 /// is intended to simply add a new route, then the existing routes need to be included in the
 /// request alongside the new route(s).
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct UpdateAccessRoutesV1 {
     pub identifier: AssetIdentifier,
     pub owner_address: String,

--- a/src/execute/update_asset_definition.rs
+++ b/src/execute/update_asset_definition.rs
@@ -15,7 +15,7 @@ use cosmwasm_std::{MessageInfo, Response};
 ///
 /// * `asset_definition` The asset definition instance to update.  Must have an [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
 /// property that matches an existing asset definition in contract storage.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct UpdateAssetDefinitionV1 {
     pub asset_definition: AssetDefinitionV2,
 }

--- a/src/execute/verify_asset.rs
+++ b/src/execute/verify_asset.rs
@@ -34,7 +34,7 @@ use cosmwasm_std::{MessageInfo, Response};
 /// of [AccessRoute](crate::core::types::access_route::AccessRoute) values to allow actors with permission
 /// to easily fetch asset data from a new location, potentially without any Provenance Blockchain
 /// interaction, facilitating the process of data interaction.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct VerifyAssetV1 {
     pub identifier: AssetIdentifier,
     pub success: bool,

--- a/src/migrate/version_info.rs
+++ b/src/migrate/version_info.rs
@@ -19,7 +19,7 @@ const VERSION_INFO: Item<VersionInfoV1> = Item::new(VERSION_INFO_NAMESPACE);
 
 /// Holds both the contract's unique name and version.
 /// Used to ensure that migrations have the correct targets and are not downgrades.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 pub struct VersionInfoV1 {
     /// The name of the contract, set to the value of [CONTRACT_NAME](self::CONTRACT_NAME) during instantiation and
     /// following migrations.

--- a/src/query/query_asset_definitions.rs
+++ b/src/query/query_asset_definitions.rs
@@ -11,7 +11,7 @@ use crate::util::{
 
 /// A simple wrapper for all asset definitions returned as a result of the [query_asset_definitions](self::query_asset_definitions)
 /// function.
-#[derive(Serialize, Deserialize, PartialEq, Clone, JsonSchema)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Clone, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct QueryAssetDefinitionsResponse {
     /// All derived asset definitions derived from the [query_asset_definitions](self::query_asset_definitions)

--- a/src/util/scope_address_utils.rs
+++ b/src/util/scope_address_utils.rs
@@ -73,7 +73,7 @@ pub fn bech32_string_to_addr<S: Into<String>>(address: S) -> AssetResult<Addr> {
     let address_string = address.into();
     // First, try to decode the string as Bech32.  If this fails, then the input is invalid and should not be converted to an Addr
     let (hrp, _, _) = bech32::decode(&address_string)?;
-    return if !VALID_HRPS.contains(&hrp.as_str()) {
+    if !VALID_HRPS.contains(&hrp.as_str()) {
         ContractError::InvalidAddress {
             address: address_string,
             explanation: format!("invalid address prefix [{}]", hrp),
@@ -82,7 +82,7 @@ pub fn bech32_string_to_addr<S: Into<String>>(address: S) -> AssetResult<Addr> {
     } else {
         // Once the address has been validated as bech32, just funnel it into the Addr struct with an unchecked call
         Addr::unchecked(&address_string).to_ok()
-    };
+    }
 }
 
 /// Takes a string representation of a UUID and converts it to a scope address by appending its


### PR DESCRIPTION
# Description
This PR adds the ability for the verifier to self-update in the `update_asset_verifier` route.  This change is ensures that the admin retains control over all verifier addition and removal, but allows for external verifiers to self-modify, ensuring that this functionality is maintainable without constant need for the admin's approval.

This change also regenerated the schema files, as well as fixing various linter issues.