### PR TITLE
Feature: Object Store Gateway Event Attributes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "3.0.0"
+version = "3.1.0"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",
@@ -31,7 +31,6 @@ incremental = false
 overflow-checks = true
 
 [features]
-backtraces = ["cosmwasm-std/backtraces"]
 library = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -255,6 +255,11 @@ can be leveraged to easily determine the source of the underlying data.  If thes
 they can always be added by using the `UpdateAccessRoutes` execution route.  Note: Access routes can specify a `name`
 parameter, as well, to indicate the reason for the route, but this is entirely optional.
 
+* `add_os_gateway_permission`: An optional parameter that will cause the emitted events to include values that signal
+to any [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway) watching the events that the
+selected verifier has permission to inspect the identified scope's records via fetch routes. This behavior defaults to
+TRUE if not explicitly provided in the json payload.
+
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `onboard_asset`.
 
@@ -268,6 +273,25 @@ execution route.
 * `asset_scope_owner_address`: This value will be the bech32 address of the owner of the scope processed in the request.
 As the request will be rejected unless it is made by the scope owner, this address should match the sender of the message
 as well.
+
+* `object_store_gateway_event_type`: This value is only emitted when `add_os_gateway_permission` is omitted or explicitly
+specified as `true`.  It will always have a value of `access_grant` and indicates to the Object Store Gateway that the
+verifier should receive permissions to inspect the records included in the scope referred to by `asset_scope_address`.
+
+* `object_store_gateway_scope_address`: This value is only emitted when `add_os_gateway_permission` is omitted or
+explicitly specified as `true`.  It will always have the same value as `asset_scope_address`, and indicates the bech32
+scope identifier to use for access grants.
+
+* `object_store_gateway_target_account_address`: This value is only emitted when `add_os_gateway_permission` is omitted
+or explicitly specified as `true`.  It will always have the same value as `asset_verifier_address`, and indicates the
+bech32 account identifier of the verifier, ensuring that the verifier receives a grant to inspect scope records.
+
+* `object_store_gateway_access_grant_id`: This value is only emitted when `add_os_gateway_permission` is omitted or
+explicitly specified as `true`.  It is a concatenation of the `asset_type` and `asset_scope_address` values, creating
+a unique identifier for an asset's verification.  This allows multiple asset type verifications to occur for the same
+scope address, working in tandem with the fact that the `verify_asset` functionality will revoke access grants from the
+verifier based on the same grant id as they are processed.  This will ensure that the verifier can only inspect scope
+data for as long as the verification process is active.
 
 ##### Request Sample
 ```json
@@ -288,7 +312,8 @@ as well.
         "route": "grpc://mycoolgrpcserver.website",
         "name": "GRPC Access"
       }
-    ]
+    ],
+    "add_os_gateway_permission": false
   }
 }
 ```
@@ -333,6 +358,13 @@ own subset of [AccessRoute](src/core/types/access_route.rs) values to allow acto
 data from a new location, potentially without any Provenance Blockchain interaction, facilitating the process of data
 interaction.
 
+* `remove_os_gateway_permission`: An optional parameter that will cause the emitted events to include values that signal
+to any [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway) watching the events that the
+verifier should no longer have permission to inspect the identified scope's records via fetch routes.  This route uses a
+unique identifier based on asset type, so if simultaneous access grants were sent to the gateway for different asset
+types' verifications on a singular scope, the verifier will retain access via the gateway until all verifications have
+been completed.  This behavior defaults to TRUE if not explicitly provided in the json payload.
+
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `verify_asset`.
 
@@ -342,6 +374,26 @@ attached to the scope that was previously onboarded before verification.
 * `asset_scope_address`: This value will be the bech32 address of the scope modified during verification.
 
 * `asset_verifier_address`: This value will be the bech32 address of the verifier invoking the execution route.
+
+* `object_store_gateway_event_type`: This value is only emitted when `remove_os_gateway_permission` is omitted or explicitly
+specified as `true`.  It will always have a value of `access_revoke` and indicates to the Object Store Gateway that the
+verifier should have its permissions to inspect the records included in the scope referred to by `asset_scope_address`
+removed.
+
+* `object_store_gateway_scope_address`: This value is only emitted when `remove_os_gateway_permission` is omitted or
+explicitly specified as `true`.  It will always have the same value as `asset_scope_address`, and indicates the bech32
+scope identifier to target an existing access grant.
+
+* `object_store_gateway_target_account_address`: This value is only emitted when `remove_os_gateway_permission` is omitted
+or explicitly specified as `true`.  It will always have the same value as `asset_verifier_address`, and indicates the
+bech32 account identifier of the verifier, ensuring that the verifier has its grant to inspect scope records revoked.
+
+* `object_store_gateway_access_grant_id`: This value is only emitted when `remove_os_gateway_permission` is omitted or
+explicitly specified as `true`.  It is a concatenation of the `asset_type` and `asset_scope_address` values, creating
+a unique identifier for an asset's verification.  This allows multiple asset type verifications to occur for the same
+scope address, working in tandem with the fact that the `verify_asset` functionality will revoke access grants from the
+verifier based on the same grant id as they are processed.  This will ensure that the verifier can only inspect scope
+data for as long as the verification process is active.
 
 ##### Request Sample
 ```json
@@ -357,7 +409,8 @@ attached to the scope that was previously onboarded before verification.
       {
         "route": "https://www.myverifierhost.verifier/api/v2/asset/417556d2-d6ec-11ec-88d8-8be6d7728b01"
       }
-    ]
+    ],
+    "remove_os_gateway_permission": false
   }
 }
 ```

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -123,6 +123,13 @@ pub enum ExecuteMsg {
         /// Note: Access routes can specify a [name](super::types::access_route::AccessRoute::name)
         /// parameter, as well, to indicate the reason for the route, but this is entirely optional.
         access_routes: Option<Vec<AccessRoute>>,
+        /// An optional parameter that will cause the emitted events to include values that signal
+        /// to any [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway)
+        /// watching the events that the selected verifier has permission to inspect the identified
+        /// scope's records via fetch routes.
+        ///
+        /// This behavior defaults to TRUE.
+        add_os_gateway_permission: Option<bool>,
     },
     /// This route is specifically designed to allow a Verifier specified in the [AssetScopeAttribute](super::types::asset_scope_attribute::AssetScopeAttribute)
     /// of a [Provenance Metadata Scope](https://docs.provenance.io/modules/metadata-module#scope-data-structures) to indicate to
@@ -154,6 +161,18 @@ pub enum ExecuteMsg {
         /// data from a new location, potentially without any Provenance Blockchain interaction, facilitating the process of data
         /// interaction.
         access_routes: Option<Vec<AccessRoute>>,
+        /// An optional parameter that will cause the emitted events to include values that signal
+        /// to any [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway)
+        /// watching the events that the verifier should no longer have permission to inspect the
+        /// identified scope's records via fetch routes.
+        ///
+        /// Note: This route uses a unique identifier based on asset type, so if simultaneous access
+        /// grants were sent to the gateway for different asset types' verifications on a singular
+        /// scope, the verifier will retain access via the gateway until all verifications have been
+        /// completed.
+        ///
+        /// This behavior defaults to TRUE.
+        remove_os_gateway_permission: Option<bool>,
     },
     /// __This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinitionV3](super::types::asset_definition::AssetDefinitionV3)
     /// value to be added to the contract's internal storage.  These asset definitions dictate which asset types are allowed to

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -126,7 +126,10 @@ pub enum ExecuteMsg {
         /// An optional parameter that will cause the emitted events to include values that signal
         /// to any [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway)
         /// watching the events that the selected verifier has permission to inspect the identified
-        /// scope's records via fetch routes.
+        /// scope's records via fetch routes.  This will only cause a gateway to grant permissions
+        /// to a scope to which the gateway itself already has read permissions.  This essentially
+        /// means that a key held by a gateway instance must have been used to store the scope's
+        /// records in [Provenance Object Store](https://github.com/provenance-io/object-store).
         ///
         /// This behavior defaults to TRUE.
         add_os_gateway_permission: Option<bool>,
@@ -161,18 +164,6 @@ pub enum ExecuteMsg {
         /// data from a new location, potentially without any Provenance Blockchain interaction, facilitating the process of data
         /// interaction.
         access_routes: Option<Vec<AccessRoute>>,
-        /// An optional parameter that will cause the emitted events to include values that signal
-        /// to any [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway)
-        /// watching the events that the verifier should no longer have permission to inspect the
-        /// identified scope's records via fetch routes.
-        ///
-        /// Note: This route uses a unique identifier based on asset type, so if simultaneous access
-        /// grants were sent to the gateway for different asset types' verifications on a singular
-        /// scope, the verifier will retain access via the gateway until all verifications have been
-        /// completed.
-        ///
-        /// This behavior defaults to TRUE.
-        remove_os_gateway_permission: Option<bool>,
     },
     /// __This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinitionV3](super::types::asset_definition::AssetDefinitionV3)
     /// value to be added to the contract's internal storage.  These asset definitions dictate which asset types are allowed to

--- a/src/core/types/fee_destination.rs
+++ b/src/core/types/fee_destination.rs
@@ -26,10 +26,10 @@ impl FeeDestinationV2 {
     /// * `address` The Provenance Blockchain bech32 address belonging to the account.
     /// * `fee_amount` The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost)
     /// of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).
-    pub fn new<S: Into<String>>(address: S, fee_amount: Uint128) -> Self {
+    pub fn new<S: Into<String>>(address: S, fee_amount: u128) -> Self {
         Self {
             address: address.into(),
-            fee_amount,
+            fee_amount: Uint128::new(fee_amount),
             entity_detail: None,
         }
     }

--- a/src/core/types/fee_payment_detail.rs
+++ b/src/core/types/fee_payment_detail.rs
@@ -223,7 +223,7 @@ mod tests {
             "address",
             Uint128::new(200),
             NHASH,
-            vec![FeeDestinationV2::new("fee", Uint128::new(101))],
+            vec![FeeDestinationV2::new("fee", 101)],
             get_default_entity_detail().to_some(),
         );
         let error = FeePaymentDetail::new(DEFAULT_SCOPE_ADDRESS, &verifier).unwrap_err();
@@ -266,7 +266,7 @@ mod tests {
             "verifier",
             Uint128::new(200),
             NHASH,
-            vec![FeeDestinationV2::new("fee-destination", Uint128::new(100))],
+            vec![FeeDestinationV2::new("fee-destination", 100)],
             None,
         );
         let messages = test_get_messages(&verifier);
@@ -290,7 +290,7 @@ mod tests {
             "verifier",
             Uint128::new(200),
             NHASH,
-            vec![FeeDestinationV2::new("fee-destination", Uint128::new(50))],
+            vec![FeeDestinationV2::new("fee-destination", 50)],
             None,
         );
         let messages = test_get_messages(&verifier);
@@ -318,11 +318,11 @@ mod tests {
             Uint128::new(400),
             NHASH,
             vec![
-                FeeDestinationV2::new("first", Uint128::new(20)),
-                FeeDestinationV2::new("second", Uint128::new(20)),
-                FeeDestinationV2::new("third", Uint128::new(40)),
-                FeeDestinationV2::new("fourth", Uint128::new(5)),
-                FeeDestinationV2::new("fifth", Uint128::new(15)),
+                FeeDestinationV2::new("first", 20),
+                FeeDestinationV2::new("second", 20),
+                FeeDestinationV2::new("third", 40),
+                FeeDestinationV2::new("fourth", 5),
+                FeeDestinationV2::new("fifth", 15),
             ],
             None,
         );

--- a/src/core/types/verifier_detail.rs
+++ b/src/core/types/verifier_detail.rs
@@ -83,7 +83,7 @@ mod tests {
             "address",
             Uint128::new(100),
             NHASH,
-            vec![FeeDestinationV2::new("fee-address", Uint128::new(55))],
+            vec![FeeDestinationV2::new("fee-address", 55)],
             None,
         );
         assert_eq!(
@@ -99,12 +99,12 @@ mod tests {
             Uint128::new(1000),
             NHASH,
             vec![
-                FeeDestinationV2::new("fee-address-1", Uint128::new(10)),
-                FeeDestinationV2::new("fee-address-2", Uint128::new(20)),
-                FeeDestinationV2::new("fee-address-3", Uint128::new(30)),
-                FeeDestinationV2::new("fee-address-4", Uint128::new(40)),
-                FeeDestinationV2::new("fee-address-5", Uint128::new(50)),
-                FeeDestinationV2::new("fee-address-6", Uint128::new(60)),
+                FeeDestinationV2::new("fee-address-1", 10),
+                FeeDestinationV2::new("fee-address-2", 20),
+                FeeDestinationV2::new("fee-address-3", 30),
+                FeeDestinationV2::new("fee-address-4", 40),
+                FeeDestinationV2::new("fee-address-5", 50),
+                FeeDestinationV2::new("fee-address-6", 60),
             ],
             None,
         );

--- a/src/execute/add_asset_definition.rs
+++ b/src/execute/add_asset_definition.rs
@@ -338,10 +338,7 @@ mod tests {
                 DEFAULT_VERIFIER_ADDRESS,
                 Uint128::new(1000),
                 NHASH,
-                vec![FeeDestinationV2::new(
-                    DEFAULT_FEE_ADDRESS,
-                    Uint128::new(500),
-                )],
+                vec![FeeDestinationV2::new(DEFAULT_FEE_ADDRESS, 500)],
                 get_default_entity_detail().to_some(),
             )],
             None,

--- a/src/execute/add_asset_verifier.rs
+++ b/src/execute/add_asset_verifier.rs
@@ -310,7 +310,7 @@ mod tests {
             TEST_VERIFIER_ADDRESS,
             Uint128::new(500000),
             NHASH,
-            vec![FeeDestinationV2::new(TEST_FEE_ADDRESS, Uint128::new(500))],
+            vec![FeeDestinationV2::new(TEST_FEE_ADDRESS, 500)],
             get_default_entity_detail().to_some(),
         );
         validate_verifier(&verifier).expect("expected the new verifier to pass validation");

--- a/src/execute/update_asset_definition.rs
+++ b/src/execute/update_asset_definition.rs
@@ -234,7 +234,7 @@ mod tests {
                 "verifier",
                 Uint128::new(100),
                 NHASH,
-                vec![FeeDestinationV2::new("fee-guy", Uint128::new(25))],
+                vec![FeeDestinationV2::new("fee-guy", 25)],
                 get_default_entity_detail().to_some(),
             )],
         );
@@ -277,14 +277,8 @@ mod tests {
                 Uint128::new(1500000),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new(
-                        "tp1knh6n2kafm78mfv0c6d6y3x3en3pcdph23r2e7",
-                        Uint128::new(450000),
-                    ),
-                    FeeDestinationV2::new(
-                        "tp1uqx5fcrx0nkcak52tt794p03d5tju62qfnwc52",
-                        Uint128::new(300000),
-                    ),
+                    FeeDestinationV2::new("tp1knh6n2kafm78mfv0c6d6y3x3en3pcdph23r2e7", 450000),
+                    FeeDestinationV2::new("tp1uqx5fcrx0nkcak52tt794p03d5tju62qfnwc52", 300000),
                 ],
                 get_default_entity_detail().to_some(),
             )],

--- a/src/execute/update_asset_verifier.rs
+++ b/src/execute/update_asset_verifier.rs
@@ -333,14 +333,8 @@ mod tests {
             Uint128::new(420),
             NHASH,
             vec![
-                FeeDestinationV2::new(
-                    "tp1av6u8yp70mf4f62vx6mzf68pkhut4ets5k4sgx",
-                    Uint128::new(105),
-                ),
-                FeeDestinationV2::new(
-                    "tp169qp36ax8gvtrzszfevqcwhe4hn2g02g35lne8",
-                    Uint128::new(105),
-                ),
+                FeeDestinationV2::new("tp1av6u8yp70mf4f62vx6mzf68pkhut4ets5k4sgx", 105),
+                FeeDestinationV2::new("tp169qp36ax8gvtrzszfevqcwhe4hn2g02g35lne8", 105),
             ],
             get_default_entity_detail().to_some(),
         );

--- a/src/execute/verify_asset.rs
+++ b/src/execute/verify_asset.rs
@@ -35,13 +35,6 @@ use cosmwasm_std::{MessageInfo, Response};
 /// of [AccessRoute](crate::core::types::access_route::AccessRoute) values to allow actors with permission
 /// to easily fetch asset data from a new location, potentially without any Provenance Blockchain
 /// interaction, facilitating the process of data interaction.
-/// * `remove_os_gateway_permission` An optional parameter that will cause the emitted events to
-/// include values that signal to any [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway)
-/// watching the events that the verifier should no longer have permission to inspect the identified
-/// scope's records via fetch routes.  This route uses a unique identifier based on asset type, so
-/// if simultaneous access grants were sent to the gateway for different asset types' verifications
-/// on a singular scope, the verifier will retain access via the gateway until all verifications
-/// have been completed.  This behavior defaults to TRUE.
 #[derive(Clone, PartialEq, Eq)]
 pub struct VerifyAssetV1 {
     pub identifier: AssetIdentifier,
@@ -49,7 +42,6 @@ pub struct VerifyAssetV1 {
     pub success: bool,
     pub message: Option<String>,
     pub access_routes: Vec<AccessRoute>,
-    pub remove_os_gateway_permission: bool,
 }
 impl VerifyAssetV1 {
     /// Attempts to create an instance of this struct from a provided execute msg.  If the provided
@@ -68,14 +60,12 @@ impl VerifyAssetV1 {
                 success,
                 message,
                 access_routes,
-                remove_os_gateway_permission,
             } => VerifyAssetV1 {
                 identifier: identifier.to_asset_identifier()?,
                 asset_type,
                 success,
                 message,
                 access_routes: access_routes.unwrap_or_default(),
-                remove_os_gateway_permission: remove_os_gateway_permission.unwrap_or(true),
             }
             .to_ok(),
             _ => ContractError::InvalidMessageType {
@@ -148,8 +138,8 @@ where
         msg.access_routes,
     )?;
 
-    // construct/emit verification attribute
-    let response = Response::new()
+    // construct/emit verification attributes
+    Response::new()
         .add_attributes(
             EventAttributes::for_asset_event(
                 EventType::VerifyAsset,
@@ -158,42 +148,34 @@ where
             )
             .set_verifier(info.sender.as_str()),
         )
-        .add_messages(repository.get_messages());
-    // TODO: Use os_gateway_contract_attributes lib once it is published to crates.io
-    let response = if msg.remove_os_gateway_permission {
-        response
-            .add_attribute("object_store_gateway_event_type", "access_revoke")
-            .add_attribute(
-                "object_store_gateway_scope_address",
-                &asset_identifiers.scope_address,
-            )
-            .add_attribute(
-                "object_store_gateway_target_account_address",
-                info.sender.as_str(),
-            )
-            .add_attribute(
-                "object_store_gateway_access_grant_id",
-                generate_os_gateway_grant_id(
-                    scope_attribute.asset_type,
-                    asset_identifiers.scope_address,
-                ),
-            )
-    } else {
-        response
-    };
-    response.to_ok()
+        // TODO: Use os_gateway_contract_attributes lib once it is published to crates.io
+        .add_attribute("object_store_gateway_event_type", "access_revoke")
+        .add_attribute(
+            "object_store_gateway_scope_address",
+            &asset_identifiers.scope_address,
+        )
+        .add_attribute(
+            "object_store_gateway_target_account_address",
+            info.sender.as_str(),
+        )
+        .add_attribute(
+            "object_store_gateway_access_grant_id",
+            generate_os_gateway_grant_id(
+                scope_attribute.asset_type,
+                asset_identifiers.scope_address,
+            ),
+        )
+        .add_messages(repository.get_messages())
+        .to_ok()
 }
 
 #[cfg(test)]
 mod tests {
-    use cosmwasm_std::testing::mock_env;
     use cosmwasm_std::Response;
     use provwasm_mocks::mock_dependencies;
     use provwasm_std::ProvenanceMsg;
     use serde_json_wasm::to_string;
 
-    use crate::contract::execute;
-    use crate::core::msg::ExecuteMsg::VerifyAsset;
     use crate::core::state::may_load_fee_payment_detail;
     use crate::execute::onboard_asset::OnboardAssetV1;
     use crate::testutil::test_constants::{
@@ -257,7 +239,6 @@ mod tests {
                 success: true,
                 message: None,
                 access_routes: vec![],
-                remove_os_gateway_permission: false,
             },
         )
         .unwrap_err();
@@ -298,7 +279,6 @@ mod tests {
                 success: true,
                 message: None,
                 access_routes: vec![],
-                remove_os_gateway_permission: false,
             },
         )
         .unwrap_err();
@@ -349,7 +329,6 @@ mod tests {
                 success: true,
                 message: "Your data sucks".to_string().to_some(),
                 access_routes: vec![],
-                remove_os_gateway_permission: false,
             },
         )
         .unwrap();
@@ -602,7 +581,8 @@ mod tests {
         let mut deps = mock_dependencies(&[]);
         setup_test_suite(&mut deps, InstArgs::default());
         test_onboard_asset(&mut deps, TestOnboardAsset::default()).unwrap();
-        test_verify_asset(&mut deps, TestVerifyAsset::default()).unwrap();
+        let response = test_verify_asset(&mut deps, TestVerifyAsset::default()).unwrap();
+        assert_verify_response_attributes_are_correct(&response);
         let attribute = AssetMetaService::new(deps.as_mut())
             .get_asset_by_asset_type(DEFAULT_SCOPE_ADDRESS, DEFAULT_ASSET_TYPE)
             .expect("after validating the asset, the scope attribute should be present");
@@ -618,7 +598,9 @@ mod tests {
         let mut deps = mock_dependencies(&[]);
         setup_test_suite(&mut deps, InstArgs::default());
         test_onboard_asset(&mut deps, TestOnboardAsset::default()).unwrap();
-        test_verify_asset(&mut deps, TestVerifyAsset::default_with_success(false)).unwrap();
+        let response =
+            test_verify_asset(&mut deps, TestVerifyAsset::default_with_success(false)).unwrap();
+        assert_verify_response_attributes_are_correct(&response);
         let attribute = AssetMetaService::new(deps.as_mut())
             .get_asset_by_asset_type(DEFAULT_SCOPE_ADDRESS, DEFAULT_ASSET_TYPE)
             .expect("after validating the asset, the scope attribute should be present");
@@ -629,55 +611,9 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_verify_with_object_store_gateway_permissions() {
-        let get_verify_result = |permission_spec: Option<bool>| {
-            let mut deps = mock_dependencies(&[]);
-            setup_test_suite(&mut deps, InstArgs::default());
-            test_onboard_asset(&mut deps, TestOnboardAsset::default()).unwrap();
-            execute(
-                deps.as_mut(),
-                mock_env(),
-                empty_mock_info(DEFAULT_VERIFIER_ADDRESS),
-                VerifyAsset {
-                    identifier: AssetIdentifier::scope_address(DEFAULT_SCOPE_ADDRESS)
-                        .to_serialized_enum(),
-                    asset_type: DEFAULT_ASSET_TYPE.to_string(),
-                    success: true,
-                    message: "did verification stuff or something".to_string().to_some(),
-                    access_routes: None,
-                    remove_os_gateway_permission: permission_spec,
-                },
-            )
-        };
-
-        // Proves that omitting the permission param will default to true and produce all expected
-        // os gateway permission attributes
-        let default_response = get_verify_result(None).expect(
-            "verification should succeed with good params and default os gateway permissions",
-        );
-        assert_verify_response_attributes_are_correct(&default_response, true);
-
-        // Proves that explicitly providing the permission param as true will produce all expected os
-        // gateway permission attributes
-        let explicit_true_response = get_verify_result(true.to_some()).expect(
-            "verification should succeed with good params and explicit true os gateway permissions",
-        );
-        assert_verify_response_attributes_are_correct(&explicit_true_response, true);
-
-        // Proves that explicitly providing the permission param as false will omit all the os
-        // gateway permission attributes
-        let explicit_false_response = get_verify_result(false.to_some())
-            .expect("verification should succeed with good params and explicit false os gateway permissions");
-        assert_verify_response_attributes_are_correct(&explicit_false_response, false);
-    }
-
-    fn assert_verify_response_attributes_are_correct(
-        response: &Response<ProvenanceMsg>,
-        expect_os_gateway_values: bool,
-    ) {
+    fn assert_verify_response_attributes_are_correct(response: &Response<ProvenanceMsg>) {
         assert_eq!(
-            4 + if expect_os_gateway_values { 4 } else { 0 },
+            8,
             response.attributes.len(),
             "the correct number of response attributes should be emitted",
         );
@@ -701,9 +637,6 @@ mod tests {
             single_attribute_for_key(response, VERIFIER_ADDRESS_KEY),
             "the correct verifier address attribute should be emitted",
         );
-        if !expect_os_gateway_values {
-            return;
-        }
         // TODO: Replace these values with constants provided by the os_gateway_contract_attributes crate
         assert_eq!(
             "access_revoke",

--- a/src/instantiate/init_contract.rs
+++ b/src/instantiate/init_contract.rs
@@ -163,7 +163,7 @@ mod tests {
                 DEFAULT_ONBOARDING_DENOM,
                 vec![FeeDestinationV2::new(
                     "tp18c94z83e6ng2sc3ylvutzytlx8zqggm554xp5a",
-                    Uint128::new(DEFAULT_ONBOARDING_COST / 4),
+                    DEFAULT_ONBOARDING_COST / 4,
                 )],
                 get_default_entity_detail().to_some(),
             )],
@@ -178,14 +178,8 @@ mod tests {
                 Uint128::new(300),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new(
-                        "tp18c94z83e6ng2sc3ylvutzytlx8zqggm554xp5a",
-                        Uint128::new(75),
-                    ),
-                    FeeDestinationV2::new(
-                        "tp1haa4tyccy0278tt9lckvu42a2g6fzjlh4vuydn",
-                        Uint128::new(75),
-                    ),
+                    FeeDestinationV2::new("tp18c94z83e6ng2sc3ylvutzytlx8zqggm554xp5a", 75),
+                    FeeDestinationV2::new("tp1haa4tyccy0278tt9lckvu42a2g6fzjlh4vuydn", 75),
                 ],
                 get_default_entity_detail().to_some(),
             )],

--- a/src/testutil/onboard_asset_helpers.rs
+++ b/src/testutil/onboard_asset_helpers.rs
@@ -23,6 +23,7 @@ impl TestOnboardAsset {
             asset_type: DEFAULT_ASSET_TYPE.to_string(),
             verifier_address: DEFAULT_VERIFIER_ADDRESS.to_string(),
             access_routes: get_default_access_routes(),
+            add_os_gateway_permission: true,
         }
     }
 

--- a/src/testutil/verify_asset_helpers.rs
+++ b/src/testutil/verify_asset_helpers.rs
@@ -28,6 +28,7 @@ impl TestVerifyAsset {
             success: true,
             message: "Verified asset without errors".to_string().to_some(),
             access_routes: get_default_access_routes(),
+            remove_os_gateway_permission: true,
         }
     }
 

--- a/src/testutil/verify_asset_helpers.rs
+++ b/src/testutil/verify_asset_helpers.rs
@@ -28,7 +28,6 @@ impl TestVerifyAsset {
             success: true,
             message: "Verified asset without errors".to_string().to_some(),
             access_routes: get_default_access_routes(),
-            remove_os_gateway_permission: true,
         }
     }
 

--- a/src/util/functions.rs
+++ b/src/util/functions.rs
@@ -60,6 +60,25 @@ pub fn generate_asset_attribute_name<T: Into<String>, U: Into<String>>(
     format!("{}.{}", asset_type.into(), base_contract_name.into())
 }
 
+/// Converts an asset type and scope address into a grant id for use with [Object Store Gateway](https://github.com/FigureTechnologies/object-store-gateway).
+/// This combination will create a value unique to each verification's process, ensuring that each
+/// selected verifier will always have access to its required scope values until any number of
+/// pending verifications complete.
+///
+/// # Parameters
+///
+/// * `asset_type` The value to use at the beginning of the grant id.  Should refer to the
+/// [asset_type](crate::core::types::asset_definition::AssetDefinitionV3::asset_type) property of an
+/// [AssetDefinitionV3](crate::core::types::asset_definition::AssetDefinitionV3).
+/// * `scope_address` The bech32 address with a prefix of "scope" that uniquely defines the scope
+/// that is currently in the process of classification.
+pub fn generate_os_gateway_grant_id<T: Into<String>, U: Into<String>>(
+    asset_type: T,
+    scope_address: U,
+) -> String {
+    format!("{}-{}", asset_type.into(), scope_address.into())
+}
+
 /// Takes an existing vector, moves it into this function, swaps out a single existing item for
 /// a specified replacement item.  If less or more than one existing item matches the given
 /// predicate closure, an error is returned.
@@ -150,7 +169,10 @@ pub fn filter_valid_access_routes(routes: Vec<AccessRoute>) -> Vec<AccessRoute> 
 mod tests {
     use crate::core::{error::ContractError, types::access_route::AccessRoute};
     use crate::testutil::test_utilities::assert_single_item;
-    use crate::util::functions::{filter_valid_access_routes, replace_single_matching_vec_element};
+    use crate::util::functions::{
+        filter_valid_access_routes, generate_os_gateway_grant_id,
+        replace_single_matching_vec_element,
+    };
     use cosmwasm_std::{BankMsg, CosmosMsg};
 
     use super::bank_send;
@@ -353,6 +375,15 @@ mod tests {
             2,
             result.len(),
             "both routes should be kept because one has a name and the other does not",
+        );
+    }
+
+    #[test]
+    fn test_generate_os_gateway_grant_id() {
+        assert_eq!(
+            "heloc-scopescopescope",
+            generate_os_gateway_grant_id("heloc", "scopescopescope"),
+            "the output value should equate to the asset type concatenated to the scope address with a hyphen",
         );
     }
 }

--- a/src/validation/validate_init_msg.rs
+++ b/src/validation/validate_init_msg.rs
@@ -226,7 +226,7 @@ pub mod tests {
                     NHASH,
                     vec![FeeDestinationV2::new(
                         "tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95",
-                        Uint128::new(100),
+                        100,
                     )],
                     get_default_entity_detail().to_some(),
                 )],
@@ -252,7 +252,7 @@ pub mod tests {
                         NHASH,
                         vec![FeeDestinationV2::new(
                             "tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95",
-                            Uint128::new(100),
+                            100,
                         )],
                         get_default_entity_detail().to_some(),
                     )],
@@ -267,14 +267,8 @@ pub mod tests {
                         Uint128::new(500),
                         NHASH,
                         vec![
-                            FeeDestinationV2::new(
-                                "tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p",
-                                Uint128::new(125),
-                            ),
-                            FeeDestinationV2::new(
-                                "tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7",
-                                Uint128::new(125),
-                            ),
+                            FeeDestinationV2::new("tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p", 125),
+                            FeeDestinationV2::new("tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7", 125),
                         ],
                         get_default_entity_detail().to_some(),
                     )],
@@ -305,11 +299,11 @@ pub mod tests {
                             vec![
                                 FeeDestinationV2::new(
                                     "tp1jdcwtaendn9y75jv9dqnmlm7dy8pv4kgu9fs9g",
-                                    Uint128::new(250000),
+                                    250000,
                                 ),
                                 FeeDestinationV2::new(
                                     "tp16dxelgu5nz7u0ygs3qu8tqzjv7gxq5wqucjclm",
-                                    Uint128::new(750000),
+                                    750000,
                                 ),
                             ],
                             get_default_entity_detail().to_some(),
@@ -336,7 +330,7 @@ pub mod tests {
                         "address",
                         Uint128::new(100),
                         NHASH,
-                        vec![FeeDestinationV2::new("fee", Uint128::new(100))],
+                        vec![FeeDestinationV2::new("fee", 100)],
                         get_default_entity_detail().to_some(),
                     )],
                     None,
@@ -405,7 +399,7 @@ pub mod tests {
                 NHASH,
                 vec![FeeDestinationV2::new(
                     "tp1pq2yt466fvxrf399atkxrxazptkkmp04x2slew",
-                    Uint128::new(100),
+                    100,
                 )],
                 get_default_entity_detail().to_some(),
             )],
@@ -428,7 +422,7 @@ pub mod tests {
                     "address",
                     Uint128::new(100),
                     NHASH,
-                    vec![FeeDestinationV2::new("fee", Uint128::new(100))],
+                    vec![FeeDestinationV2::new("fee", 100)],
                     get_default_entity_detail().to_some(),
                 )],
             ),
@@ -454,7 +448,7 @@ pub mod tests {
                     "",
                     Uint128::new(100),
                     NHASH,
-                    vec![FeeDestinationV2::new("fee", Uint128::new(100))],
+                    vec![FeeDestinationV2::new("fee", 100)],
                     get_default_entity_detail().to_some(),
                 )],
             ),
@@ -487,7 +481,7 @@ pub mod tests {
             NHASH,
             vec![FeeDestinationV2::new(
                 "tp143p2m575fqre9rmaf9tpqwp9ux0mrzv83tdfh6",
-                Uint128::new(50),
+                50,
             )],
             get_default_entity_detail().to_some(),
         );
@@ -506,23 +500,11 @@ pub mod tests {
             Uint128::new(4000),
             NHASH,
             vec![
-                FeeDestinationV2::new(
-                    "tp14evhfcwnj9hz8p49lysp6uvz6ch3lq8r29xv89",
-                    Uint128::new(100),
-                ),
-                FeeDestinationV2::new(
-                    "tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95",
-                    Uint128::new(1650),
-                ),
-                FeeDestinationV2::new(
-                    "tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p",
-                    Uint128::new(50),
-                ),
-                FeeDestinationV2::new(
-                    "tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7",
-                    Uint128::new(199),
-                ),
-                FeeDestinationV2::new("tp1aujf44ge8zydwckk8zwa5g548czys53dkcp2lq", Uint128::new(1)),
+                FeeDestinationV2::new("tp14evhfcwnj9hz8p49lysp6uvz6ch3lq8r29xv89", 100),
+                FeeDestinationV2::new("tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95", 1650),
+                FeeDestinationV2::new("tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p", 50),
+                FeeDestinationV2::new("tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7", 199),
+                FeeDestinationV2::new("tp1aujf44ge8zydwckk8zwa5g548czys53dkcp2lq", 1),
             ],
             get_default_entity_detail().to_some(),
         );
@@ -585,7 +567,7 @@ pub mod tests {
                 "address",
                 Uint128::new(2020),
                 NHASH,
-                vec![FeeDestinationV2::new("fee", Uint128::new(1011))],
+                vec![FeeDestinationV2::new("fee", 1011)],
                 get_default_entity_detail().to_some(),
             ),
             "verifier:fee_destinations:fee_amounts must sum to be less than or equal to half the onboarding cost",
@@ -600,8 +582,8 @@ pub mod tests {
                 Uint128::new(100),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new("fee-guy", Uint128::new(25)),
-                    FeeDestinationV2::new("fee-guy", Uint128::new(25)),
+                    FeeDestinationV2::new("fee-guy", 25),
+                    FeeDestinationV2::new("fee-guy", 25),
                 ],
                 get_default_entity_detail().to_some(),
             ),
@@ -616,7 +598,7 @@ pub mod tests {
                 "address",
                 Uint128::new(100),
                 NHASH,
-                vec![FeeDestinationV2::new("", Uint128::new(100))],
+                vec![FeeDestinationV2::new("", 100)],
                 get_default_entity_detail().to_some(),
             ),
             "fee_destination:address: must be a valid address",
@@ -625,10 +607,7 @@ pub mod tests {
 
     #[test]
     fn test_valid_destination() {
-        let destination = FeeDestinationV2::new(
-            "tp1362ax9s0gxr5yy636q2p9uuefeg8lhguvu6np5",
-            Uint128::new(100),
-        );
+        let destination = FeeDestinationV2::new("tp1362ax9s0gxr5yy636q2p9uuefeg8lhguvu6np5", 100);
         assert!(
             validate_destination_internal(&destination).is_empty(),
             "a valid fee destination should pass validation and return no error messages",
@@ -638,7 +617,7 @@ pub mod tests {
     #[test]
     fn test_invalid_destination_address() {
         test_invalid_destination(
-            &FeeDestinationV2::new("", Uint128::new(1)),
+            &FeeDestinationV2::new("", 1),
             "fee_destination:address: must be a valid address",
         );
     }
@@ -646,7 +625,7 @@ pub mod tests {
     #[test]
     fn test_invalid_destination_fee_amount_too_low() {
         test_invalid_destination(
-            &FeeDestinationV2::new("good-address", Uint128::zero()),
+            &FeeDestinationV2::new("good-address", 0),
             "fee_destination:fee_amount: must not be zero",
         );
     }


### PR DESCRIPTION
# Description
This PR is to add object store gateway event attributes to asset classification onboards and verifications.  

## Changes
- Bump version to `v3.1.0`.
- Add an optional param to the `onboard_asset` execute action that emits OS gateway event attributes.  This values defaults to true but can be disabled by explicitly providing `false`.
- Automatically emit object store access revocation attributes on the verify asset route to ensure that verification grants do not persist after the verifier is done with them.
- Add a `generate_os_gateway_grant_id` function that ensures that values sent to the gateway for grant ids are uniform across all invocations.
- QOL: Tweak `FeeDestinationV2`'s `new` constructor to use a `u128` for more concise syntax.
- QOL: Remove unneeded migration test code now that it's successfully worked on testnet.

## Note
We're still waiting on a Figure Tech account for publishing to crates.io, so this PR manually supplies all object store gateway attributes.  Due to this, I didn't take any time to create specific constants for those values - they will be automatically specified correctly by the underlying library once `os_gateway_contract_attributes` is published to crates.io.  This change will be added in v3.1.1.