### PR TITLE
v3.1.1: Use OS gateway lib + result extensions lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,17 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",
  "cosmwasm-std",
  "cosmwasm-storage",
  "cw-storage-plus",
+ "os-gateway-contract-attributes",
  "provwasm-mocks",
  "provwasm-std",
+ "result-extensions",
  "schemars",
  "semver",
  "serde",
@@ -368,6 +370,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "os-gateway-contract-attributes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074b93795d3cc939d472278081f9b419414776e8ef0c8d315c600559495fd93b"
+
+[[package]]
 name = "pkcs8"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -436,6 +444,12 @@ checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom 0.2.6",
 ]
+
+[[package]]
+name = "result-extensions"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6a16927a77de33f43b4f98a52bd08ae9d17e3a5d98e4a413d54b5fb431cfd6b"
 
 [[package]]
 name = "rfc6979"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "3.1.0"
+version = "3.1.1"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",
@@ -39,6 +39,8 @@ provwasm-std = { version = "=1.1.0" }
 cosmwasm-std = { version = "=1.0.0" }
 cosmwasm-storage = { version = "=1.0.0" }
 cw-storage-plus = "=0.12.1"
+os-gateway-contract-attributes = "=1.0.1"
+result-extensions = "=1.0.2"
 schemars = "=0.8.3"
 semver = "=1.0.7"
 serde = { version = "=1.0.137", default-features = false, features = ["derive"] }

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,12 +1,10 @@
 use crate::core::types::asset_definition::AssetDefinitionV3;
 use crate::core::types::fee_payment_detail::FeePaymentDetail;
-use crate::{
-    core::msg::InitMsg,
-    util::{aliases::AssetResult, traits::ResultExtensions},
-};
+use crate::{core::msg::InitMsg, util::aliases::AssetResult};
 use cosmwasm_std::{Addr, Storage};
 use cosmwasm_storage::{singleton, singleton_read, ReadonlySingleton, Singleton};
 use cw_storage_plus::Map;
+use result_extensions::ResultExtensions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/src/core/types/access_definition.rs
+++ b/src/core/types/access_definition.rs
@@ -1,9 +1,8 @@
+use result_extensions::ResultExtensions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use crate::util::{
-    aliases::AssetResult, scope_address_utils::bech32_string_to_addr, traits::ResultExtensions,
-};
+use crate::util::{aliases::AssetResult, scope_address_utils::bech32_string_to_addr};
 
 use super::access_route::AccessRoute;
 

--- a/src/core/types/asset_definition.rs
+++ b/src/core/types/asset_definition.rs
@@ -1,3 +1,4 @@
+use result_extensions::ResultExtensions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -9,7 +10,6 @@ use crate::{
     util::{
         aliases::{AssetResult, DepsC},
         functions::generate_asset_attribute_name,
-        traits::ResultExtensions,
     },
 };
 

--- a/src/core/types/asset_identifier.rs
+++ b/src/core/types/asset_identifier.rs
@@ -1,12 +1,12 @@
 use crate::core::error::ContractError;
 use crate::core::types::serialized_enum::SerializedEnum;
+use result_extensions::ResultExtensions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::util::{
     aliases::AssetResult,
     scope_address_utils::{asset_uuid_to_scope_address, scope_address_to_asset_uuid},
-    traits::ResultExtensions,
 };
 
 const ASSET_UUID_NAME: &str = "asset_uuid";

--- a/src/core/types/asset_scope_attribute.rs
+++ b/src/core/types/asset_scope_attribute.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::Addr;
+use result_extensions::ResultExtensions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -6,7 +7,7 @@ use crate::{
     core::types::access_definition::AccessDefinitionType,
     util::{
         aliases::AssetResult, functions::filter_valid_access_routes,
-        scope_address_utils::bech32_string_to_addr, traits::ResultExtensions,
+        scope_address_utils::bech32_string_to_addr,
     },
 };
 

--- a/src/core/types/fee_payment_detail.rs
+++ b/src/core/types/fee_payment_detail.rs
@@ -3,9 +3,10 @@ use crate::core::types::fee_destination::FeeDestinationV2;
 use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::util::aliases::AssetResult;
 use crate::util::functions::bank_send;
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{coin, Addr, Coin, CosmosMsg};
 use provwasm_std::ProvenanceMsg;
+use result_extensions::ResultExtensions;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 

--- a/src/execute/add_asset_definition.rs
+++ b/src/execute/add_asset_definition.rs
@@ -6,9 +6,10 @@ use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
 use crate::util::event_attributes::{EventAttributes, EventType};
 use crate::util::functions::generate_asset_attribute_name;
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{Env, MessageInfo, Response};
 use provwasm_std::{bind_name, NameBinding};
+use result_extensions::ResultExtensions;
 
 /// A transformation of [ExecuteMsg::AddAssetDefinition](crate::core::msg::ExecuteMsg::AddAssetDefinition)
 /// for ease of use in the underlying [add_asset_definition](self::add_asset_definition) function.

--- a/src/execute/add_asset_verifier.rs
+++ b/src/execute/add_asset_verifier.rs
@@ -5,8 +5,9 @@ use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
 use crate::util::event_attributes::{EventAttributes, EventType};
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{MessageInfo, Response};
+use result_extensions::ResultExtensions;
 
 /// A transformation of [ExecuteMsg::AddAssetVerifier](crate::core::msg::ExecuteMsg::AddAssetVerifier)
 /// for ease of use in the underlying [add_asset_verifier](self::add_asset_verifier) function.

--- a/src/execute/delete_asset_definition.rs
+++ b/src/execute/delete_asset_definition.rs
@@ -4,8 +4,9 @@ use crate::core::state::delete_asset_definition_by_asset_type_v3;
 use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
 use crate::util::event_attributes::{EventAttributes, EventType};
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{MessageInfo, Response};
+use result_extensions::ResultExtensions;
 
 /// A transformation of [ExecuteMsg::DeleteAssetDefinition](crate::core::msg::ExecuteMsg::DeleteAssetDefinition)
 /// for ease of use in the underlying [delete_asset_definition](self::delete_asset_definition) function.

--- a/src/execute/onboard_asset.rs
+++ b/src/execute/onboard_asset.rs
@@ -12,9 +12,11 @@ use crate::util::aliases::{AssetResult, EntryPointResponse};
 use crate::util::contract_helpers::check_funds_are_empty;
 use crate::util::event_attributes::{EventAttributes, EventType};
 use crate::util::functions::generate_os_gateway_grant_id;
-use crate::util::traits::{OptionExtensions, ResultExtensions};
+use crate::util::traits::OptionExtensions;
 use cosmwasm_std::{Env, MessageInfo, Response};
+use os_gateway_contract_attributes::OsGatewayAttributeGenerator;
 use provwasm_std::ProvenanceQuerier;
+use result_extensions::ResultExtensions;
 
 /// A transformation of [ExecuteMsg::OnboardAsset](crate::core::msg::ExecuteMsg::OnboardAsset)
 /// for ease of use in the underlying [onboard_asset](self::onboard_asset) function.
@@ -230,22 +232,17 @@ where
             .set_scope_owner(info.sender),
         )
         .add_messages(repository.get_messages());
-    // TODO: Use os_gateway_contract_attributes lib once it is published to crates.io
     let response = if msg.add_os_gateway_permission {
-        response
-            .add_attribute("object_store_gateway_event_type", "access_grant")
-            .add_attribute(
-                "object_store_gateway_scope_address",
+        response.add_attributes(
+            OsGatewayAttributeGenerator::access_grant(
                 &asset_identifiers.scope_address,
-            )
-            .add_attribute(
-                "object_store_gateway_target_account_address",
                 msg.verifier_address,
             )
-            .add_attribute(
-                "object_store_gateway_access_grant_id",
-                generate_os_gateway_grant_id(msg.asset_type, asset_identifiers.scope_address),
-            )
+            .with_access_grant_id(generate_os_gateway_grant_id(
+                msg.asset_type,
+                asset_identifiers.scope_address,
+            )),
+        )
     } else {
         response
     };
@@ -256,6 +253,7 @@ where
 mod tests {
     use cosmwasm_std::testing::{mock_env, MOCK_CONTRACT_ADDR};
     use cosmwasm_std::{coins, from_binary, CosmosMsg, Response, StdError, Uint128};
+    use os_gateway_contract_attributes::{OS_GATEWAY_EVENT_TYPES, OS_GATEWAY_KEYS};
     use provwasm_mocks::mock_dependencies;
     use provwasm_std::{
         AttributeMsgParams, AttributeValueType, MsgFeesMsgParams, Process, ProcessId,
@@ -1189,25 +1187,24 @@ mod tests {
         if !expect_os_gateway_values {
             return;
         }
-        // TODO: Replace these values with constants provided by the os_gateway_contract_attributes crate
         assert_eq!(
-            "access_grant",
-            single_attribute_for_key(response, "object_store_gateway_event_type"),
+            OS_GATEWAY_EVENT_TYPES.access_grant,
+            single_attribute_for_key(response, OS_GATEWAY_KEYS.event_type),
             "the correct object store gateway event type attribute should be emitted",
         );
         assert_eq!(
             DEFAULT_SCOPE_ADDRESS,
-            single_attribute_for_key(response, "object_store_gateway_scope_address"),
+            single_attribute_for_key(response, OS_GATEWAY_KEYS.scope_address),
             "the correct object store gateway scope address attribute should be emitted",
         );
         assert_eq!(
             DEFAULT_VERIFIER_ADDRESS,
-            single_attribute_for_key(response, "object_store_gateway_target_account_address"),
+            single_attribute_for_key(response, OS_GATEWAY_KEYS.target_account),
             "the correct object store gateway target account address attribute should be emitted",
         );
         assert_eq!(
             generate_os_gateway_grant_id(DEFAULT_ASSET_TYPE, DEFAULT_SCOPE_ADDRESS),
-            single_attribute_for_key(response, "object_store_gateway_access_grant_id"),
+            single_attribute_for_key(response, OS_GATEWAY_KEYS.access_grant_id),
             "the correct object store gateway access grant id attribute should be emitted",
         );
     }

--- a/src/execute/toggle_asset_definition.rs
+++ b/src/execute/toggle_asset_definition.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{MessageInfo, Response};
+use result_extensions::ResultExtensions;
 
 use crate::core::state::{load_asset_definition_by_type_v3, replace_asset_definition_v3};
 use crate::{
@@ -7,7 +8,6 @@ use crate::{
         aliases::{AssetResult, DepsMutC, EntryPointResponse},
         contract_helpers::{check_admin_only, check_funds_are_empty},
         event_attributes::{EventAttributes, EventType},
-        traits::ResultExtensions,
     },
 };
 

--- a/src/execute/update_access_routes.rs
+++ b/src/execute/update_access_routes.rs
@@ -11,8 +11,9 @@ use crate::util::aliases::{AssetResult, EntryPointResponse};
 use crate::util::contract_helpers::check_funds_are_empty;
 use crate::util::event_attributes::{EventAttributes, EventType};
 use crate::util::functions::filter_valid_access_routes;
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{MessageInfo, Response};
+use result_extensions::ResultExtensions;
 
 /// A transformation of [ExecuteMsg::UpdateAccessRoutes](crate::core::msg::ExecuteMsg::UpdateAccessRoutes)
 /// for ease of use in the underlying [update_access_routes](self::update_access_routes) function.

--- a/src/execute/update_asset_definition.rs
+++ b/src/execute/update_asset_definition.rs
@@ -5,8 +5,9 @@ use crate::core::types::asset_definition::AssetDefinitionV3;
 use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
 use crate::util::event_attributes::{EventAttributes, EventType};
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{MessageInfo, Response};
+use result_extensions::ResultExtensions;
 
 /// A transformation of [ExecuteMsg::UpdateAssetDefinition](crate::core::msg::ExecuteMsg::UpdateAssetDefinition)
 /// for ease of use in the underlying [update_asset_definition](self::update_asset_definition) function.

--- a/src/execute/update_asset_verifier.rs
+++ b/src/execute/update_asset_verifier.rs
@@ -8,8 +8,9 @@ use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::check_funds_are_empty;
 use crate::util::event_attributes::{EventAttributes, EventType};
 use crate::util::functions::replace_single_matching_vec_element;
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{MessageInfo, Response};
+use result_extensions::ResultExtensions;
 
 /// A transformation of [ExecuteMsg::UpdateAssetVerifier](crate::core::msg::ExecuteMsg::UpdateAssetVerifier)
 /// for ease of use in the underlying [update_asset_verifier](self::update_asset_verifier) function.

--- a/src/instantiate/init_contract.rs
+++ b/src/instantiate/init_contract.rs
@@ -5,9 +5,10 @@ use crate::util::aliases::{DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::check_funds_are_empty;
 use crate::util::event_attributes::{EventAttributes, EventType};
 use crate::util::functions::generate_asset_attribute_name;
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{CosmosMsg, Env, MessageInfo, Response};
 use provwasm_std::{bind_name, NameBinding, ProvenanceMsg};
+use result_extensions::ResultExtensions;
 
 /// The main functionality executed when the smart contract is first instantiated.   This creates
 /// the internal contract [StateV2](crate::core::state::StateV2) value, as well as any provided

--- a/src/migrate/migrate_contract.rs
+++ b/src/migrate/migrate_contract.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::{Response, Storage};
+use result_extensions::ResultExtensions;
 use semver::Version;
 
 use crate::core::msg::MigrationOptions;
@@ -10,7 +11,6 @@ use crate::{
     util::{
         aliases::{AssetResult, DepsMutC, EntryPointResponse},
         event_attributes::{EventAttributes, EventType},
-        traits::ResultExtensions,
     },
 };
 

--- a/src/query/query_asset_definition.rs
+++ b/src/query/query_asset_definition.rs
@@ -1,7 +1,8 @@
 use crate::core::state::may_load_asset_definition_by_type_v3;
 use crate::util::aliases::{AssetResult, DepsC};
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{to_binary, Binary};
+use result_extensions::ResultExtensions;
 
 /// A query that fetches a target [AssetDefinitionV3](crate::core::types::asset_definition::AssetDefinitionV3)
 /// from the contract's internal storage.

--- a/src/query/query_asset_definitions.rs
+++ b/src/query/query_asset_definitions.rs
@@ -1,10 +1,8 @@
 use cosmwasm_std::{to_binary, Binary};
+use result_extensions::ResultExtensions;
 
 use crate::core::state::list_asset_definitions_v3;
-use crate::util::{
-    aliases::{AssetResult, DepsC},
-    traits::ResultExtensions,
-};
+use crate::util::aliases::{AssetResult, DepsC};
 
 /// A query that fetches all [AssetDefinitionV3s](crate::core::types::asset_definition::AssetDefinitionV3)
 /// from the contract's internal storage.

--- a/src/query/query_asset_scope_attribute.rs
+++ b/src/query/query_asset_scope_attribute.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use cosmwasm_std::{from_binary, to_binary, Addr, Binary};
 use provwasm_std::{AttributeValueType, ProvenanceQuerier};
+use result_extensions::ResultExtensions;
 
 use crate::{
     core::{
@@ -12,7 +13,6 @@ use crate::{
     util::{
         aliases::{AssetResult, DepsC},
         scope_address_utils::asset_uuid_to_scope_address,
-        traits::ResultExtensions,
     },
 };
 

--- a/src/query/query_asset_scope_attribute_by_asset_type.rs
+++ b/src/query/query_asset_scope_attribute_by_asset_type.rs
@@ -1,5 +1,6 @@
 use cosmwasm_std::{to_binary, Addr, Binary};
 use provwasm_std::ProvenanceQuerier;
+use result_extensions::ResultExtensions;
 
 use crate::{
     core::{
@@ -10,7 +11,6 @@ use crate::{
     util::{
         aliases::{AssetResult, DepsC},
         scope_address_utils::asset_uuid_to_scope_address,
-        traits::ResultExtensions,
     },
 };
 

--- a/src/query/query_fee_payments.rs
+++ b/src/query/query_fee_payments.rs
@@ -1,8 +1,9 @@
 use crate::core::state::may_load_fee_payment_detail;
 use crate::core::types::asset_identifier::AssetIdentifier;
 use crate::util::aliases::{AssetResult, DepsC};
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{to_binary, Binary};
+use result_extensions::ResultExtensions;
 
 /// A query that fetches a target [FeePaymentDetail](crate::core::types::fee_payment_detail::FeePaymentDetail)
 /// from the contract's internal storage and serializes it to a [Binary](cosmwasm_std::Binary)

--- a/src/query/query_state.rs
+++ b/src/query/query_state.rs
@@ -1,11 +1,9 @@
 use cosmwasm_std::{to_binary, Binary};
+use result_extensions::ResultExtensions;
 
 use crate::{
     core::state::config_read_v2,
-    util::{
-        aliases::{AssetResult, DepsC},
-        traits::ResultExtensions,
-    },
+    util::aliases::{AssetResult, DepsC},
 };
 
 /// A query that directly returns the contract's stored [StateV2](crate::core::state::StateV2) value.

--- a/src/query/query_version.rs
+++ b/src/query/query_version.rs
@@ -1,11 +1,9 @@
 use cosmwasm_std::{to_binary, Binary};
+use result_extensions::ResultExtensions;
 
 use crate::{
     migrate::version_info::get_version_info,
-    util::{
-        aliases::{AssetResult, DepsC},
-        traits::ResultExtensions,
-    },
+    util::aliases::{AssetResult, DepsC},
 };
 
 /// Pulls the version info for the contract out of the version store.

--- a/src/service/asset_meta_service.rs
+++ b/src/service/asset_meta_service.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 
 use cosmwasm_std::{to_binary, Coin, CosmosMsg, Env};
 use provwasm_std::{assess_custom_fee, update_attribute, AttributeValueType, ProvenanceMsg};
+use result_extensions::ResultExtensions;
 
 use crate::core::state::{
     delete_fee_payment_detail, insert_fee_payment_detail, load_fee_payment_detail,
@@ -29,9 +30,9 @@ use crate::{
     },
     util::aliases::{AssetResult, DepsMutC},
     util::deps_container::DepsContainer,
+    util::functions::filter_valid_access_routes,
     util::functions::generate_asset_attribute_name,
     util::vec_container::VecContainer,
-    util::{functions::filter_valid_access_routes, traits::ResultExtensions},
     util::{
         provenance_util::get_add_attribute_to_scope_msg, scope_address_utils::bech32_string_to_addr,
     },

--- a/src/util/contract_helpers.rs
+++ b/src/util/contract_helpers.rs
@@ -1,8 +1,9 @@
 use crate::core::error::ContractError;
 use crate::core::state::config_read_v2;
 use crate::util::aliases::{AssetResult, DepsC};
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::MessageInfo;
+use result_extensions::ResultExtensions;
 
 /// Ensures that only the admin of the contract can call into a route.
 ///

--- a/src/util/functions.rs
+++ b/src/util/functions.rs
@@ -1,9 +1,10 @@
 use crate::core::error::ContractError;
 use crate::core::types::access_route::AccessRoute;
 use crate::util::aliases::AssetResult;
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::{coin, BankMsg, CosmosMsg};
 use provwasm_std::ProvenanceMsg;
+use result_extensions::ResultExtensions;
 use std::collections::HashSet;
 use std::hash::Hash;
 

--- a/src/util/scope_address_utils.rs
+++ b/src/util/scope_address_utils.rs
@@ -3,9 +3,8 @@ use std::{convert::TryInto, str::FromStr};
 use crate::{core::error::ContractError, util::aliases::AssetResult};
 use bech32::{FromBase32, ToBase32, Variant};
 use cosmwasm_std::Addr;
+use result_extensions::ResultExtensions;
 use uuid::Uuid;
-
-use super::traits::ResultExtensions;
 
 // Standard scope key prefix from the Provenance libs
 const KEY_SCOPE: u8 = 0x00;

--- a/src/util/traits.rs
+++ b/src/util/traits.rs
@@ -1,21 +1,3 @@
-/// Allows any Sized type to functionally move itself into a Result<T, U>
-pub trait ResultExtensions
-where
-    Self: Sized,
-{
-    /// Converts the caller into an Ok (left-hand-side) result
-    fn to_ok<E>(self) -> Result<Self, E> {
-        Ok(self)
-    }
-
-    /// Converts the caller into an Err (right-hand-side) result
-    fn to_err<T>(self) -> Result<T, Self> {
-        Err(self)
-    }
-}
-// Implement for EVERYTHING IN THE UNIVERSE
-impl<T> ResultExtensions for T {}
-
 /// Allows any Sized type to functionally move itself into an Option<T>
 pub trait OptionExtensions
 where
@@ -30,31 +12,7 @@ impl<T> OptionExtensions for T {}
 
 #[cfg(test)]
 mod tests {
-    use crate::core::error::ContractError;
-
-    use super::{OptionExtensions, ResultExtensions};
-
-    #[test]
-    fn test_to_ok() {
-        let value: Result<String, ContractError> = "hello".to_string().to_ok();
-        assert_eq!(
-            "hello".to_string(),
-            value.unwrap(),
-            "expected the value to serialize correctly",
-        );
-    }
-
-    #[test]
-    fn test_to_err() {
-        let result: Result<(), ContractError> =
-            ContractError::InvalidFunds("no u".to_string()).to_err();
-        let error = result.unwrap_err();
-        assert!(
-            matches!(error, ContractError::InvalidFunds(_)),
-            "the error should unwrap correctly, but got incorrect error: {:?}",
-            error,
-        );
-    }
+    use super::OptionExtensions;
 
     #[test]
     fn test_to_option() {

--- a/src/validation/validate_execute_msg.rs
+++ b/src/validation/validate_execute_msg.rs
@@ -4,10 +4,11 @@ use crate::core::types::asset_identifier::AssetIdentifier;
 use crate::core::types::serialized_enum::SerializedEnum;
 use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::util::aliases::AssetResult;
-use crate::util::traits::{OptionExtensions, ResultExtensions};
+use crate::util::traits::OptionExtensions;
 use crate::validation::validate_init_msg::{
     validate_asset_definition, validate_verifier_with_provided_errors,
 };
+use result_extensions::ResultExtensions;
 
 /// The main branch of validation for an execute msg.  Funnels the intercepted value based on variant
 /// to one of the various sub-functions in this module.

--- a/src/validation/validate_init_msg.rs
+++ b/src/validation/validate_init_msg.rs
@@ -7,8 +7,9 @@ use crate::util::aliases::AssetResult;
 use crate::util::constants::VALID_VERIFIER_DENOMS;
 use crate::util::functions::distinct_count_by_property;
 use crate::util::scope_address_utils::bech32_string_to_addr;
-use crate::util::traits::ResultExtensions;
+
 use cosmwasm_std::Uint128;
+use result_extensions::ResultExtensions;
 
 /// Validates the integrity of an intercepted [InitMsg](crate::core::msg::InitMsg) and its
 /// associated [AssetDefinitionV3](crate::core::types::asset_definition::AssetDefinitionV3) values.


### PR DESCRIPTION
# Description
This PR is to start using the `os-gateway-contract-attributes` library that automatically appends the required attributes for OS gateway grants / revokes to emitted messages.  This simply replaces the hardcoded values used in v3.1.0.  Additionally, this introduces my `result-extensions` library to prove that it's smart-contract-safe and because it's less code we have to re-write for future things.