### PR TITLE
v3.3.0: Remove provenance msg fees 50% reduction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ dependencies = [
  "schemars",
  "semver",
  "serde",
- "serde-json-wasm",
+ "serde-json-wasm 0.4.1",
  "thiserror",
  "uuid",
 ]
@@ -57,6 +57,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,17 +79,17 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb0afef2325df81aadbf9be1233f522ed8f6e91df870c764bc44cca2b1415bd"
+checksum = "cb56fffc2233212e9546df66e01267277173d55f6237ab939690ef2c5cfd50c2"
 dependencies = [
- "digest",
+ "digest 0.10.6",
  "ed25519-zebra",
  "k256",
  "rand_core 0.6.3",
@@ -89,45 +98,62 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b36e527620a2a3e00e46b6e731ab6c9b68d11069c986f7d7be8eba79ef081a4"
+checksum = "e26a78e202d602a23fd5d13dff898732814ebe7a8bde20f1bf71eb0209d56d56"
 dependencies = [
  "syn",
 ]
 
 [[package]]
 name = "cosmwasm-schema"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772e80bbad231a47a2068812b723a1ff81dd4a0d56c9391ac748177bea3a61da"
+checksum = "1a3dfcfa0c6f4b9aef8820c0a999410f239828a4503a388ce8e55f59fe3ac863"
 dependencies = [
+ "cosmwasm-schema-derive",
  "schemars",
+ "serde",
  "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "cosmwasm-schema-derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19cd48063eef5b92a0aabcf0687705802178ae175571dfdc5f3b925d0741d39"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "cosmwasm-std"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875994993c2082a6fcd406937bf0fca21c349e4a624f3810253a14fa83a3a195"
+checksum = "7b50f4deaed6196047a3ceec9bc23e85d4292b73442d77af63723842d8b6049d"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
  "cosmwasm-derive",
+ "derivative",
  "forward_ref",
+ "hex",
  "schemars",
  "serde",
- "serde-json-wasm",
+ "serde-json-wasm 0.5.0",
+ "sha2 0.10.6",
  "thiserror",
  "uint",
 ]
 
 [[package]]
 name = "cosmwasm-storage"
-version = "1.0.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d18403b07304d15d304dad11040d45bbcaf78d603b4be3fb5e2685c16f9229b5"
+checksum = "c91b9880577b6fa389f60bbcc8daab202996150c51ed0d14e6532a87a764a7d5"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -150,9 +176,9 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.3.2"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -161,13 +187,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
@@ -177,7 +203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
- "digest",
+ "digest 0.9.0",
  "rand_core 0.5.1",
  "subtle",
  "zeroize",
@@ -196,11 +222,23 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
+ "zeroize",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -213,6 +251,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,9 +269,9 @@ checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "ecdsa"
-version = "0.13.4"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d69ae62e0ce582d56380743515fefaf1a8c70cec685d9677636d7e30ae9dc9"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -240,23 +289,25 @@ dependencies = [
  "hex",
  "rand_core 0.6.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "elliptic-curve"
-version = "0.11.12"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b477563c2bfed38a3b7a60964c49e058b2510ad3f12ba3483fd8f62c2306d6"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
+ "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
+ "pkcs8",
  "rand_core 0.6.3",
  "sec1",
  "subtle",
@@ -265,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "131655483be284720a17d74ff97592b8e76576dc25563148601df2d7c9080924"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "rand_core 0.6.3",
  "subtle",
@@ -313,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "group"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5ac374b108929de78460075f3dc439fa66df9d8fc77e8f12caa5165fcf0c89"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
  "rand_core 0.6.3",
@@ -330,12 +381,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -346,15 +396,14 @@ checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
 name = "k256"
-version = "0.10.4"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3a5e0a0b8450278feda242592512e09f61c72e018b8cd5c859482802daf2d"
+checksum = "72c1e0b51e7ec0a97369623508396067a486bd0cbed95a2659a4b863d28cfc8b"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sec1",
- "sha2",
+ "sha2 0.10.6",
 ]
 
 [[package]]
@@ -377,13 +426,12 @@ checksum = "074b93795d3cc939d472278081f9b419414776e8ef0c8d315c600559495fd93b"
 
 [[package]]
 name = "pkcs8"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
- "zeroize",
 ]
 
 [[package]]
@@ -397,9 +445,9 @@ dependencies = [
 
 [[package]]
 name = "provwasm-mocks"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90b0dc19138397cabf8050dc4a7ddbb47dc3e7ba5e1a50cae23a014f436c4f1"
+checksum = "7fcf3ceea156c4457e938023b6b4e8893ae6a00e02608e725d5712443872dfe5"
 dependencies = [
  "cosmwasm-std",
  "provwasm-std",
@@ -409,9 +457,9 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af27a7939f7a89df3937d9eb05de442154dc29e51716e5704af2019705b1593"
+checksum = "a78a7ba9df5e8fb865e441a02c92dc473df67d1cb88aaeb07bdc4a3beb37d593"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -453,9 +501,9 @@ checksum = "e6a16927a77de33f43b4f98a52bd08ae9d17e3a5d98e4a413d54b5fb431cfd6b"
 
 [[package]]
 name = "rfc6979"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ef608575f6392792f9ecf7890c00086591d29a83910939d430753f7c050525"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
 dependencies = [
  "crypto-bigint",
  "hmac",
@@ -470,9 +518,9 @@ checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "schemars"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6ab463ae35acccb5cba66c0084c985257b797d288b6050cc2f6ac1b266cb78"
+checksum = "2a5fb6c61f29e723026dc8e923d94c694313212abbecbbe5f55a7748eec5b307"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -482,9 +530,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "902fdfbcf871ae8f653bddf4b2c05905ddaabc08f69d32a915787e3be0d31356"
+checksum = "f188d036977451159430f3b8dc82ec76364a42b7e289c2b18a9a18f4470058e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -494,10 +542,11 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08da66b8b0965a5555b6bd6639e68ccba85e1e2506f5fbb089e93f8a04e1a2d1"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
+ "base16ct",
  "der",
  "generic-array",
  "pkcs8",
@@ -530,6 +579,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-json-wasm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15bee9b04dd165c3f4e142628982ddde884c2022a89e8ddf99c4829bf2c3a58"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbab34ca63057a1f15280bdf3c39f2b1eb1b54c17e98360e511637aef7418c6"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -568,28 +626,39 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.9.0",
  "opaque-debug",
 ]
 
 [[package]]
-name = "signature"
-version = "1.4.0"
+name = "sha2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02658e48d89f2bec991f9a78e69cfa4c316f8d6a6c4ec12fae1aeb263d486788"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
- "digest",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.6",
  "rand_core 0.6.3",
 ]
 
 [[package]]
 name = "spki"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "3.2.1"
+version = "3.3.0"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,13 +35,13 @@ library = []
 
 [dependencies]
 bech32 = "=0.8.1"
-provwasm-std = { version = "=1.1.0" }
-cosmwasm-std = { version = "=1.0.0" }
-cosmwasm-storage = { version = "=1.0.0" }
+provwasm-std = { version = "=1.1.2" }
+cosmwasm-std = { version = "=1.2.0" }
+cosmwasm-storage = { version = "=1.2.0" }
 cw-storage-plus = "=0.12.1"
 os-gateway-contract-attributes = "=1.0.1"
 result-extensions = "=1.0.2"
-schemars = "=0.8.3"
+schemars = "=0.8.11"
 semver = "=1.0.7"
 serde = { version = "=1.0.137", default-features = false, features = ["derive"] }
 serde-json-wasm = { version = "=0.4.1" }
@@ -49,6 +49,6 @@ thiserror = { version = "=1.0.26" }
 uuid = "=0.8.2"
 
 [dev-dependencies]
-provwasm-mocks = { version = "=1.1.0" }
-cosmwasm-schema = { version = "=1.0.0" }
+provwasm-mocks = { version = "=1.1.2" }
+cosmwasm-schema = { version = "=1.2.0" }
 uuid = { version = "=0.8.2", features = ["v4"] }

--- a/schema/asset_identifier.json
+++ b/schema/asset_identifier.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AssetIdentifier",
   "description": "An enum containing interchangeable values that can be used to define an asset (uuid or address).",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "A uuid v4 represented by a string.",
       "type": "object",

--- a/schema/asset_scope_attribute.json
+++ b/schema/asset_scope_attribute.json
@@ -101,10 +101,21 @@
     },
     "AccessDefinitionType": {
       "description": "Allows access definitions to be differentiated based on their overarching type, versus having to differentiate them based on known addresses.",
-      "type": "string",
-      "enum": [
-        "requestor",
-        "verifier"
+      "oneOf": [
+        {
+          "description": "Indicates that the access definition was created by the requestor that onboarded the scope.",
+          "type": "string",
+          "enum": [
+            "requestor"
+          ]
+        },
+        {
+          "description": "Indicates that the access definition was created by the verifier for a scope.",
+          "type": "string",
+          "enum": [
+            "verifier"
+          ]
+        }
       ]
     },
     "AccessRoute": {
@@ -133,11 +144,28 @@
     },
     "AssetOnboardingStatus": {
       "description": "An enum that denotes the various states that an [AssetScopeAttribute](super::asset_scope_attribute::AssetScopeAttribute) can have.",
-      "type": "string",
-      "enum": [
-        "pending",
-        "denied",
-        "approved"
+      "oneOf": [
+        {
+          "description": "Indicates that the asset has been onboarded but has yet to be verified.",
+          "type": "string",
+          "enum": [
+            "pending"
+          ]
+        },
+        {
+          "description": "Indicates that the asset has been verified and is determined to be unfit to be classified as its designated asset type.",
+          "type": "string",
+          "enum": [
+            "denied"
+          ]
+        },
+        {
+          "description": "Indicates that the asset has been verified and has been successfully classified as its designated asset type.",
+          "type": "string",
+          "enum": [
+            "approved"
+          ]
+        }
       ]
     },
     "AssetVerificationResult": {

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ExecuteMsg",
   "description": "Defines all routes in which the contract can be executed.  These are all handled directly in the [contract file](crate::contract::execute).",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "This route is the primary interaction point for most consumers.  It consumes an asset uuid or scope address, the type of asset corresponding to that scope (heloc, mortgage, payable, etc), and, if all checks pass, attaches an attribute to the provided scope that stages the scope for verification of authenticity by the specified verifier in the request.  The attribute is attached based on the [base_contract_name](self::InitMsg::base_contract_name) specified in the contract, combined with the specified asset type in the request.  Ex: if [base_contract_name](self::InitMsg::base_contract_name) is \"asset\" and the asset type is \"myasset\", the attribute would be assigned under the name of \"myasset.asset\".  All available asset types are queryable, and stored in the contract as [AssetDefinitionV3](super::types::asset_definition::AssetDefinitionV3) values.  After onboarding is completed, an [AssetScopeAttribute](super::types::asset_scope_attribute::AssetScopeAttribute) will be stored on the scope with an [AssetOnboardingStatus](super::types::asset_onboarding_status::AssetOnboardingStatus) of [Pending](super::types::asset_onboarding_status::AssetOnboardingStatus::Pending), indicating that the asset has been onboarded to the contract but is awaiting verification.",
       "type": "object",

--- a/schema/fee_payment_detail.json
+++ b/schema/fee_payment_detail.json
@@ -50,7 +50,7 @@
       ],
       "properties": {
         "amount": {
-          "description": "The amount to be charged during the asset verification process.  The denom will always match the [onboarding_denom](super::verifier_detail::VerifierDetailV2::onboarding_denom) amount.  The coin's amount will be equal to the amount for a fee_destination in the verifier detail, and (onboarding_cost / 2) - fee_destination_total for the verifier itself if that amount is > 0.",
+          "description": "The amount to be charged during the asset verification process.  The denom will always match the [onboarding_denom](super::verifier_detail::VerifierDetailV2::onboarding_denom) amount.  The coin's amount will be equal to the amount for a fee_destination in the verifier detail, and (onboarding_cost- fee_destination_total0 for the verifier itself if that amount is > 0.",
           "allOf": [
             {
               "$ref": "#/definitions/Coin"

--- a/schema/fee_payment_detail.json
+++ b/schema/fee_payment_detail.json
@@ -50,7 +50,7 @@
       ],
       "properties": {
         "amount": {
-          "description": "The amount to be charged during the asset verification process.  The denom will always match the [onboarding_denom](super::verifier_detail::VerifierDetailV2::onboarding_denom) amount.  The coin's amount will be equal to the amount for a fee_destination in the verifier detail, and (onboarding_cost- fee_destination_total0 for the verifier itself if that amount is > 0.",
+          "description": "The amount to be charged during the asset verification process.  The denom will always match the [onboarding_denom](super::verifier_detail::VerifierDetailV2::onboarding_denom) amount.  The coin's amount will be equal to the amount for a fee_destination in the verifier detail, and (onboarding_cost- fee_destination_total) for the verifier itself if that amount is > 0.",
           "allOf": [
             {
               "$ref": "#/definitions/Coin"

--- a/schema/migrate_msg.json
+++ b/schema/migrate_msg.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
   "description": "The struct used to migrate the contract from one code instance to another.  Utilized in the core [contract file](crate::contract::migrate).",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "Performs a standard migration using the underlying [migrate_contract](crate::migrate::migrate_contract::migrate_contract) function.",
       "type": "object",

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "QueryMsg",
   "description": "Defines all routes in which the contract can be queried.  These are all handled directly in the [contract file](crate::contract::query).",
-  "anyOf": [
+  "oneOf": [
     {
       "description": "This route can be used to retrieve a specific [AssetDefinitionV3](super::types::asset_definition::AssetDefinitionV3) from the contract's internal storage for inspection of its verifies and other properties.  If the requested value is not found, a null response will be returned.",
       "type": "object",

--- a/src/core/types/fee_payment_detail.rs
+++ b/src/core/types/fee_payment_detail.rs
@@ -126,7 +126,7 @@ pub struct FeePayment {
     /// The amount to be charged during the asset verification process.  The denom will always
     /// match the [onboarding_denom](super::verifier_detail::VerifierDetailV2::onboarding_denom)
     /// amount.  The coin's amount will be equal to the amount for a fee_destination in the verifier detail,
-    /// and (onboarding_cost- fee_destination_total0 for the verifier itself if that amount is > 0.
+    /// and (onboarding_cost- fee_destination_total) for the verifier itself if that amount is > 0.
     pub amount: Coin,
     /// A name describing to the end user (requestor) the purpose and target of the fee.
     pub name: String,

--- a/src/core/types/fee_payment_detail.rs
+++ b/src/core/types/fee_payment_detail.rs
@@ -64,7 +64,7 @@ impl FeePaymentDetail {
             });
             fee_total += destination.fee_amount.u128();
         }
-        // Fee distribution can, at most, be equal to half the onboarding cost (half to account for the 50% fee cut that the custom fee distributes).  The onboarding cost should
+        // Fee distribution can, at most, be equal to the onboarding cost.  The onboarding cost should
         // always reflect the exact total that is taken from the requestor address when onboarding a new
         // scope.
         if fee_total > onboarding_cost.cost.u128() {
@@ -425,13 +425,6 @@ mod tests {
         assert_eq!(6, messages.len(), "expected six messages to be sent");
         test_messages_contains_fee_for_address(
             &messages,
-            "verifier",
-            200,
-            NHASH,
-            "expected half of all funds to be sent to the verifier",
-        );
-        test_messages_contains_fee_for_address(
-            &messages,
             "first",
             40,
             NHASH,
@@ -464,6 +457,13 @@ mod tests {
             30,
             NHASH,
             "expected 15 nhash of the fee to be sent to the fifth fee destination",
+        );
+        test_messages_contains_fee_for_address(
+            &messages,
+            "verifier",
+            200,
+            NHASH,
+            "expected all remaining funds to be sent to the verifier",
         );
     }
 

--- a/src/core/types/fee_payment_detail.rs
+++ b/src/core/types/fee_payment_detail.rs
@@ -67,20 +67,18 @@ impl FeePaymentDetail {
         // Fee distribution can, at most, be equal to half the onboarding cost (half to account for the 50% fee cut that the custom fee distributes).  The onboarding cost should
         // always reflect the exact total that is taken from the requestor address when onboarding a new
         // scope.
-        if fee_total > onboarding_cost.cost.u128() / 2 {
+        if fee_total > onboarding_cost.cost.u128() {
             return ContractError::generic(
-                format!("misconfigured fee destinations! fee total ({}{}) was greater than half the specified onboarding cost ({}{} / 2 = {}{})",
+                format!("misconfigured fee destinations! fee total ({}{}) was greater than the specified onboarding cost ({}{})",
                         fee_total,
                         &verifier.onboarding_denom,
                         onboarding_cost.cost.u128(),
-                        &verifier.onboarding_denom,
-                        onboarding_cost.cost.u128() / 2,
                         &verifier.onboarding_denom,
                 )
             ).to_err();
         }
         // The total funds disbursed to the verifier itself is the remainder from subtracting the fee cost from the onboarding cost
-        let verifier_cost = (onboarding_cost.cost.u128() / 2) - fee_total;
+        let verifier_cost = onboarding_cost.cost.u128() - fee_total;
         // Only append payment info for the verifier if it actually has a cost
         if verifier_cost > 0 {
             payments.push(FeePayment {
@@ -128,7 +126,7 @@ pub struct FeePayment {
     /// The amount to be charged during the asset verification process.  The denom will always
     /// match the [onboarding_denom](super::verifier_detail::VerifierDetailV2::onboarding_denom)
     /// amount.  The coin's amount will be equal to the amount for a fee_destination in the verifier detail,
-    /// and (onboarding_cost / 2) - fee_destination_total for the verifier itself if that amount is > 0.
+    /// and (onboarding_cost- fee_destination_total0 for the verifier itself if that amount is > 0.
     pub amount: Coin,
     /// A name describing to the end user (requestor) the purpose and target of the fee.
     pub name: String,
@@ -297,7 +295,7 @@ mod tests {
             "address",
             Uint128::new(200),
             NHASH,
-            vec![FeeDestinationV2::new("fee", 101)],
+            vec![FeeDestinationV2::new("fee", 201)],
             get_default_entity_detail().to_some(),
             None,
             None,
@@ -313,7 +311,7 @@ mod tests {
         match error {
             ContractError::GenericError { msg } => {
                 assert_eq!(
-                    "misconfigured fee destinations! fee total (101nhash) was greater than half the specified onboarding cost (200nhash / 2 = 100nhash)",
+                    "misconfigured fee destinations! fee total (201nhash) was greater than the specified onboarding cost (200nhash)",
                     msg.as_str(),
                     "unexpected error message generated",
                 );
@@ -345,7 +343,7 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             "verifier",
-            100,
+            200,
             NHASH,
             "expected all funds to be sent to the verifier",
         );
@@ -357,7 +355,7 @@ mod tests {
             "verifier",
             Uint128::new(200),
             NHASH,
-            vec![FeeDestinationV2::new("fee-destination", 100)],
+            vec![FeeDestinationV2::new("fee-destination", 200)],
             None,
             None,
             None,
@@ -371,7 +369,7 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             "fee-destination",
-            100,
+            200,
             NHASH,
             "expected all funds to be sent to the fee destination",
         );
@@ -383,7 +381,7 @@ mod tests {
             "verifier",
             Uint128::new(200),
             NHASH,
-            vec![FeeDestinationV2::new("fee-destination", 50)],
+            vec![FeeDestinationV2::new("fee-destination", 100)],
             None,
             None,
             None,
@@ -393,14 +391,14 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             "verifier",
-            50,
+            100,
             NHASH,
             "expected half of the funds to be sent to the verifier",
         );
         test_messages_contains_fee_for_address(
             &messages,
             "fee-destination",
-            50,
+            100,
             NHASH,
             "expected half of the funds to be sent to the fee destination",
         );
@@ -413,11 +411,11 @@ mod tests {
             Uint128::new(400),
             NHASH,
             vec![
-                FeeDestinationV2::new("first", 20),
-                FeeDestinationV2::new("second", 20),
-                FeeDestinationV2::new("third", 40),
-                FeeDestinationV2::new("fourth", 5),
-                FeeDestinationV2::new("fifth", 15),
+                FeeDestinationV2::new("first", 40),
+                FeeDestinationV2::new("second", 40),
+                FeeDestinationV2::new("third", 80),
+                FeeDestinationV2::new("fourth", 10),
+                FeeDestinationV2::new("fifth", 30),
             ],
             None,
             None,
@@ -428,42 +426,42 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             "verifier",
-            100,
+            200,
             NHASH,
             "expected half of all funds to be sent to the verifier",
         );
         test_messages_contains_fee_for_address(
             &messages,
             "first",
-            20,
+            40,
             NHASH,
             "expected 20 nhash of the fee to be sent to the first fee destination",
         );
         test_messages_contains_fee_for_address(
             &messages,
             "second",
-            20,
+            40,
             NHASH,
             "expected 20 nhash of the fee to be sent to the second fee destination",
         );
         test_messages_contains_fee_for_address(
             &messages,
             "third",
-            40,
+            80,
             NHASH,
             "expected 40 nhash of the fee to be sent to the third fee destination",
         );
         test_messages_contains_fee_for_address(
             &messages,
             "fourth",
-            5,
+            10,
             NHASH,
             "expected 5 nhash of the fee to be sent to the fourth fee destination",
         );
         test_messages_contains_fee_for_address(
             &messages,
             "fifth",
-            15,
+            30,
             NHASH,
             "expected 15 nhash of the fee to be sent to the fifth fee destination",
         );
@@ -485,9 +483,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             "verifier",
-            80,
+            180,
             NHASH,
-            "expected half of the funds to be sent to the verifier, minus the 20 for fee",
+            "expected the funds to be sent to the verifier, minus the 20 for fee",
         );
         test_messages_contains_fee_for_address(
             &messages,
@@ -526,9 +524,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             DEFAULT_VERIFIER_ADDRESS,
-            100,
+            400,
             NHASH,
-            "the verifier should receive the correct amount of nhash: 600 / 2 - 200fee = 100",
+            "the verifier should receive the correct amount of nhash: 600 - 200fee = 400",
         );
         test_messages_contains_fee_for_address(
             &messages,
@@ -554,9 +552,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             "verifier",
-            65,
+            140,
             NHASH,
-            "the correct amount of nhash should be sent to the verifier: 150 /2 - 10fee = 65",
+            "the correct amount of nhash should be sent to the verifier: 150 - 10fee = 140",
         );
         test_messages_contains_fee_for_address(
             &messages,
@@ -595,9 +593,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             DEFAULT_VERIFIER_ADDRESS,
-            150,
+            400,
             NHASH,
-            "expected 150 nhash to go to the verifier: 500 / 2 - 100fee = 150",
+            "expected 400 nhash to go to the verifier: 500 - 100fee = 400",
         );
         test_messages_contains_fee_for_address(
             &messages,
@@ -632,9 +630,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             DEFAULT_VERIFIER_ADDRESS,
-            50,
+            150,
             NHASH,
-            "the verifier should receive the correct amount of nhash: 200 / 2 - 50fee = 50",
+            "the verifier should receive the correct amount of nhash: 200 - 50fee = 150",
         );
         test_messages_contains_fee_for_address(
             &messages,
@@ -673,9 +671,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             DEFAULT_VERIFIER_ADDRESS,
-            490,
+            990,
             NHASH,
-            "the verifier should receive the correct amount of nhash: 1000 / 2 - 10fee = 490",
+            "the verifier should receive the correct amount of nhash: 1000 - 10fee = 990",
         );
         test_messages_contains_fee_for_address(
             &messages,
@@ -718,9 +716,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             DEFAULT_VERIFIER_ADDRESS,
-            400,
+            850,
             NHASH,
-            "the verifier should receive the correct amount of nhash: 900 / 2 - 50fee = 400",
+            "the verifier should receive the correct amount of nhash: 900 - 50fee = 850",
         );
         test_messages_contains_fee_for_address(
             &messages,
@@ -761,9 +759,9 @@ mod tests {
         test_messages_contains_fee_for_address(
             &messages,
             DEFAULT_VERIFIER_ADDRESS,
-            400,
+            850,
             NHASH,
-            "the verifier should receive the correct amount of nhash: 900 / 2 - 50fee = 400",
+            "the verifier should receive the correct amount of nhash: 900 - 50fee = 850",
         );
         test_messages_contains_fee_for_address(
             &messages,

--- a/src/execute/onboard_asset.rs
+++ b/src/execute/onboard_asset.rs
@@ -979,7 +979,7 @@ mod tests {
                 .retry_cost
                 .expect("the default verifier should have a retry cost")
                 .cost
-                .u128() / 2,
+                .u128(),
             payment_detail_after_retry.sum_costs(),
             "the payments in the generated detail should sum to the defined retry cost divided by two to account for provenance fee handling",
         );
@@ -1249,7 +1249,7 @@ mod tests {
         let secondary_asset_definition = AssetDefinitionV3::new(
             DEFAULT_SECONDARY_ASSET_TYPE,
             Some("secondary asset"),
-            vec![secondary_verifier.clone()],
+            vec![secondary_verifier],
         );
         add_asset_definition(
             deps.as_mut(),
@@ -1287,9 +1287,9 @@ mod tests {
         );
         let payment_detail = subsequent_onboard_fee_detail.payments.first().unwrap();
         assert_eq!(
-            150,
+            300,
             payment_detail.amount.amount.u128(),
-            "the payment amount should be 300, which is half of the default onboarding cost",
+            "the payment amount should be 300, which is the entirety of the onboarding cost",
         );
         assert_eq!(
             DEFAULT_VERIFIER_ADDRESS,

--- a/src/validation/validate_init_msg.rs
+++ b/src/validation/validate_init_msg.rs
@@ -199,17 +199,10 @@ fn validate_onboarding_cost_internal<S: Into<String>>(
 ) -> Vec<String> {
     let source = source.into();
     let mut invalid_fields: Vec<String> = vec![];
-    // onboarding cost must be even, as the Provenance Message Fees module takes half and we need to know how much goes into contract escrow exactly
-    if onboarding_cost.cost.u128() % 2 != 0 {
-        invalid_fields.push(format!(
-            "{}: onboarding_cost:cost must be an even number",
-            source
-        ));
-    }
     if !onboarding_cost.fee_destinations.is_empty()
-        && onboarding_cost.get_fee_total() > onboarding_cost.cost.u128() / 2
+        && onboarding_cost.get_fee_total() > onboarding_cost.cost.u128()
     {
-        invalid_fields.push(format!("{}: onboarding_cost:fee_destinations:fee_amounts must sum to be less than or equal to half the onboarding cost", source));
+        invalid_fields.push(format!("{}: onboarding_cost:fee_destinations:fee_amounts must sum to be less than or equal to the onboarding cost", source));
     }
     if distinct_count_by_property(&onboarding_cost.fee_destinations, |dest| &dest.address)
         != onboarding_cost.fee_destinations.len()
@@ -294,7 +287,7 @@ pub mod tests {
                     NHASH,
                     vec![FeeDestinationV2::new(
                         "tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95",
-                        100,
+                        200,
                     )],
                     get_default_entity_detail().to_some(),
                     None,
@@ -322,7 +315,7 @@ pub mod tests {
                         NHASH,
                         vec![FeeDestinationV2::new(
                             "tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95",
-                            100,
+                            200,
                         )],
                         get_default_entity_detail().to_some(),
                         None,
@@ -339,8 +332,8 @@ pub mod tests {
                         Uint128::new(500),
                         NHASH,
                         vec![
-                            FeeDestinationV2::new("tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p", 125),
-                            FeeDestinationV2::new("tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7", 125),
+                            FeeDestinationV2::new("tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p", 250),
+                            FeeDestinationV2::new("tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7", 250),
                         ],
                         get_default_entity_detail().to_some(),
                         None,
@@ -375,11 +368,11 @@ pub mod tests {
                             vec![
                                 FeeDestinationV2::new(
                                     "tp1jdcwtaendn9y75jv9dqnmlm7dy8pv4kgu9fs9g",
-                                    250000,
+                                    500000,
                                 ),
                                 FeeDestinationV2::new(
                                     "tp16dxelgu5nz7u0ygs3qu8tqzjv7gxq5wqucjclm",
-                                    750000,
+                                    1500000,
                                 ),
                             ],
                             get_default_entity_detail().to_some(),
@@ -479,7 +472,7 @@ pub mod tests {
                 NHASH,
                 vec![FeeDestinationV2::new(
                     "tp1pq2yt466fvxrf399atkxrxazptkkmp04x2slew",
-                    100,
+                    200,
                 )],
                 get_default_entity_detail().to_some(),
                 None,
@@ -609,11 +602,11 @@ pub mod tests {
             Uint128::new(4000),
             NHASH,
             vec![
-                FeeDestinationV2::new("tp14evhfcwnj9hz8p49lysp6uvz6ch3lq8r29xv89", 100),
-                FeeDestinationV2::new("tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95", 1650),
-                FeeDestinationV2::new("tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p", 50),
-                FeeDestinationV2::new("tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7", 199),
-                FeeDestinationV2::new("tp1aujf44ge8zydwckk8zwa5g548czys53dkcp2lq", 1),
+                FeeDestinationV2::new("tp14evhfcwnj9hz8p49lysp6uvz6ch3lq8r29xv89", 200),
+                FeeDestinationV2::new("tp16e7gwxzr2g5ktfsa69mhy2qqtwxy3g3eansn95", 3300),
+                FeeDestinationV2::new("tp1szfeeasdxjdj55sps0m8835wppkykj5wgkhu2p", 100),
+                FeeDestinationV2::new("tp1m2ar35p73amqxwaxgcya0tckd0nmm9l9xe74l7", 398),
+                FeeDestinationV2::new("tp1aujf44ge8zydwckk8zwa5g548czys53dkcp2lq", 2),
             ],
             get_default_entity_detail().to_some(),
             None,
@@ -684,12 +677,12 @@ pub mod tests {
                 "address",
                 Uint128::new(2020),
                 NHASH,
-                vec![FeeDestinationV2::new("fee", 1011)],
+                vec![FeeDestinationV2::new("fee", 2021)],
                 get_default_entity_detail().to_some(),
                 None,
                 None,
             ),
-            "verifier onboarding costs: onboarding_cost:fee_destinations:fee_amounts must sum to be less than or equal to half the onboarding cost",
+            "verifier onboarding costs: onboarding_cost:fee_destinations:fee_amounts must sum to be less than or equal to the onboarding cost",
         );
     }
 
@@ -701,8 +694,8 @@ pub mod tests {
                 Uint128::new(100),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new("fee-guy", 25),
-                    FeeDestinationV2::new("fee-guy", 25),
+                    FeeDestinationV2::new("fee-guy", 50),
+                    FeeDestinationV2::new("fee-guy", 50),
                 ],
                 get_default_entity_detail().to_some(),
                 None,
@@ -739,23 +732,8 @@ pub mod tests {
                 Uint128::new(100),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new("fee-guy", 25),
-                    FeeDestinationV2::new("fee-guy", 25),
-                ],
-                get_default_entity_detail().to_some(),
-                OnboardingCost::new(3, &[]).to_some(),
-                None,
-            ),
-            "verifier retry costs: onboarding_cost:cost must be an even number",
-        );
-        test_invalid_verifier(
-            &VerifierDetailV2::new(
-                "address",
-                Uint128::new(100),
-                NHASH,
-                vec![
-                    FeeDestinationV2::new("fee-guy", 25),
-                    FeeDestinationV2::new("fee-guy", 25),
+                    FeeDestinationV2::new("fee-guy", 50),
+                    FeeDestinationV2::new("fee-guy", 50),
                 ],
                 get_default_entity_detail().to_some(),
                 OnboardingCost::new(4, &[FeeDestinationV2::new("", 2)]).to_some(),
@@ -796,27 +774,8 @@ pub mod tests {
                 Uint128::new(100),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new("fee-guy", 25),
-                    FeeDestinationV2::new("fee-guy", 25),
-                ],
-                get_default_entity_detail().to_some(),
-                None,
-                SubsequentClassificationDetail::new::<String>(
-                    OnboardingCost::new(3, &[]).to_some(),
-                    &[],
-                )
-                .to_some(),
-            ),
-            "verifier subsequent classification cost: onboarding_cost:cost must be an even number",
-        );
-        test_invalid_verifier(
-            &VerifierDetailV2::new(
-                "address",
-                Uint128::new(100),
-                NHASH,
-                vec![
-                    FeeDestinationV2::new("fee-guy", 25),
-                    FeeDestinationV2::new("fee-guy", 25),
+                    FeeDestinationV2::new("fee-guy", 50),
+                    FeeDestinationV2::new("fee-guy", 50),
                 ],
                 get_default_entity_detail().to_some(),
                 None,
@@ -838,8 +797,8 @@ pub mod tests {
                 Uint128::new(100),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new("fee-guy", 25),
-                    FeeDestinationV2::new("fee-guy", 25),
+                    FeeDestinationV2::new("fee-guy", 50),
+                    FeeDestinationV2::new("fee-guy", 50),
                 ],
                 get_default_entity_detail().to_some(),
                 None,
@@ -857,8 +816,8 @@ pub mod tests {
                 Uint128::new(100),
                 NHASH,
                 vec![
-                    FeeDestinationV2::new("fee-guy", 25),
-                    FeeDestinationV2::new("fee-guy", 25),
+                    FeeDestinationV2::new("fee-guy", 50),
+                    FeeDestinationV2::new("fee-guy", 50),
                 ],
                 get_default_entity_detail().to_some(),
                 None,


### PR DESCRIPTION
# Description
Provenance will remove the 50% fee cut from provenance msg fees in their next upgrade.  This change should prepare us for when that release goes live.  If this gets added to mainnet via governance proposal, we can wait to migrate it til the new provenance version releases that removes the fee, allowing a seamless transition to the new way of charging fees.

## Changes
- Upgrade provenance, cosmwasm, and schemars dependencies to stay relatively up to date with the latest changes.
- Remove all logic that depends on the `assess_custom_fee` logic that charges 50% to Proenance.