### PR TITLE
v3.2.1: Audit fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "3.2.0"
+version = "3.2.1"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/src/execute/verify_asset.rs
+++ b/src/execute/verify_asset.rs
@@ -132,20 +132,15 @@ where
         .to_err();
     }
 
-    let updated_attribute = repository.verify_asset(
-        &asset_identifiers.scope_address,
-        msg.asset_type,
-        msg.success,
-        msg.message,
-        msg.access_routes,
-    )?;
+    let updated_attribute =
+        repository.verify_asset(scope_attribute, msg.success, msg.message, msg.access_routes)?;
 
     // construct/emit verification attributes
     Response::new()
         .add_attributes(
             EventAttributes::for_asset_event(
                 EventType::VerifyAsset,
-                &scope_attribute.asset_type,
+                &updated_attribute.asset_type,
                 &asset_identifiers.scope_address,
             )
             .set_verifier(info.sender.as_str())
@@ -157,7 +152,7 @@ where
                 info.sender.as_str(),
             )
             .with_access_grant_id(generate_os_gateway_grant_id(
-                scope_attribute.asset_type,
+                &updated_attribute.asset_type,
                 asset_identifiers.scope_address,
             )),
         )

--- a/src/service/asset_meta_repository.rs
+++ b/src/service/asset_meta_repository.rs
@@ -105,8 +105,8 @@ pub trait AssetMetaRepository {
     ///
     /// # Parameters
     ///
-    /// * `scope_address` A Provenance Blockchain bech32 address with an hrp of "scope".  Links to
-    /// the desired scope to verify.
+    /// * `scope_attribute` The [AssetScopeAttribute](crate::core::types::asset_scope_attribute::AssetScopeAttribute)
+    /// to be verified.
     /// * `success` Whether or not the scope should be considered verified when the process completes.
     /// * `verification_message` An optional value that will be displayed to external observers when
     /// fetching the [AssetScopeAttribute](crate::core::types::asset_scope_attribute::AssetScopeAttribute)
@@ -114,12 +114,11 @@ pub trait AssetMetaRepository {
     /// * `access_routes` Additional access routes that the verifier provides for external consumers
     /// to retrieve the underlying asset data from the scope, potentially without access an object
     /// store.
-    fn verify_asset<S1: Into<String>, S2: Into<String>, S3: Into<String>>(
+    fn verify_asset<S: Into<String>>(
         &self,
-        scope_address: S1,
-        asset_type: S2,
+        scope_attribute: AssetScopeAttribute,
         success: bool,
-        verification_message: Option<S3>,
+        verification_message: Option<S>,
         access_routes: Vec<AccessRoute>,
     ) -> AssetResult<AssetScopeAttribute>;
 }

--- a/src/validation/validate_init_msg.rs
+++ b/src/validation/validate_init_msg.rs
@@ -130,6 +130,14 @@ fn validate_asset_definition_internal(asset_definition: &AssetDefinitionV3) -> V
                 .to_string(),
         );
     }
+    if distinct_count_by_property(&asset_definition.verifiers, |verifier| &verifier.address)
+        != asset_definition.verifiers.len()
+    {
+        invalid_fields.push(
+            "asset_definitions:verifiers: each verifier detail must have a unique address"
+                .to_string(),
+        );
+    }
     let mut verifier_messages = asset_definition
         .verifiers
         .iter()
@@ -519,6 +527,37 @@ pub mod tests {
         test_invalid_asset_definition(
             &AssetDefinitionV3::new("mortgage", "MORTGAGE".to_some(), vec![]),
             "asset_definition:verifiers: at least one verifier must be supplied per asset type",
+        );
+    }
+
+    #[test]
+    fn test_invalid_asset_definition_duplicate_verifier_addresses() {
+        test_invalid_asset_definition(
+            &AssetDefinitionV3::new(
+                "heloc",
+                "very best heloc ever".to_some(),
+                vec![
+                    VerifierDetailV2::new(
+                        "duplicate",
+                        Uint128::new(100),
+                        NHASH,
+                        vec![FeeDestinationV2::new("fee", 100)],
+                        get_default_entity_detail().to_some(),
+                        None,
+                        None,
+                    ),
+                    VerifierDetailV2::new(
+                        "duplicate",
+                        Uint128::new(100),
+                        NHASH,
+                        vec![FeeDestinationV2::new("fee", 100)],
+                        get_default_entity_detail().to_some(),
+                        None,
+                        None,
+                    ),
+                ],
+            ),
+            "asset_definitions:verifiers: each verifier detail must have a unique address",
         );
     }
 


### PR DESCRIPTION
# Description
This PR addresses various requested changes from an informal audit of the repository for efficiency and safety.  The requested changes are in the following locations:

* https://github.com/informalsystems/audit-figure/blob/trunk/2022-2023/Q4-Q1/report/src/findings/IF-FIGURE-AC-ARBITRARY-APPLICABLE-ASSET-TYPES.md
* https://github.com/informalsystems/audit-figure/blob/trunk/2022-2023/Q4-Q1/report/src/findings/IF-FIGURE-AC-DUPLICATE-METHOD-CALLS.md
* https://github.com/informalsystems/audit-figure/blob/trunk/2022-2023/Q4-Q1/report/src/findings/IF-FIGURE-AC-DUPLICATE-VERIFIER-IN-ASSET.md
* https://github.com/informalsystems/audit-figure/blob/trunk/2022-2023/Q4-Q1/report/src/findings/IF-FIGURE-AC-SAVING-ZERO-FEES.md

## ID Notes
### IF-FIGURE-AC-ARBITRARY-APPLICABLE-ASSET-TYPES
* No changes made due to allowing specification of nonexistent asset types purposefully during initial configurations

### IF-FIGURE-AC-UNNECESSARY-METHOD-CALLS
* Removed is_retry check entirely.  As the ID denotes, this check is redundant.
* Add scope attribute dependency to verify_asset function. This prevents duplicate lookups of the attribute when it is already available to the only invoking function.

### IF-FIGURE-AC-DUPLICATE-VERIFIER-IN-ASSET
* Added duplicate verifier address check to verifier detail validation.  Validation runs on both contract instantiation and the `add_asset_definition_v3` function, so centralizing this check to the validation fixes both concerns.

### IF-FIGURE-AC-SAVING-ZERO-FEES
* Opted to keep existing saves for zero fees just for auditing purposes, but avoided append_messages call when fees are empty